### PR TITLE
Validate SamplingSchedule constructor parameters

### DIFF
--- a/thrml/block_sampling.py
+++ b/thrml/block_sampling.py
@@ -416,6 +416,21 @@ class SamplingSchedule:
     n_samples: int
     steps_per_sample: int
 
+    def __post_init__(self):
+        if not isinstance(self.n_warmup, int):
+            raise TypeError(f"n_warmup must be int, got {type(self.n_warmup).__name__}")
+        if not isinstance(self.n_samples, int):
+            raise TypeError(f"n_samples must be int, got {type(self.n_samples).__name__}")
+        if not isinstance(self.steps_per_sample, int):
+            raise TypeError(f"steps_per_sample must be int, got {type(self.steps_per_sample).__name__}")
+
+        if self.n_warmup < 0:
+            raise ValueError(f"n_warmup must be non-negative, got {self.n_warmup}")
+        if self.n_samples < 1:
+            raise ValueError(f"n_samples must be positive, got {self.n_samples}")
+        if self.steps_per_sample < 1:
+            raise ValueError(f"steps_per_sample must be positive, got {self.steps_per_sample}")
+
     def __hash__(self) -> int:
         return hash((self.n_warmup, self.n_samples, self.steps_per_sample))
 


### PR DESCRIPTION
Adds input validation to catch invalid parameters at construction time to `thmrl/block_sampling.py`
Validates `SamplingSchedule` parameters at construction time to prevent cryptic errors downstream.

**Before:**
```python
schedule = SamplingSchedule(n_warmup=-10, n_samples=100, steps_per_sample=2)
# Object created successfully, error occurs during sampling:
# TypeError: broadcast_in_dim shape must have every element be nonnegative...
```

**After:**
```python
schedule = SamplingSchedule(n_warmup=-10, n_samples=100, steps_per_sample=2)
# Object creation fails immediately with clear message:
# ValueError: n_warmup must be non-negative, got -10
```

Validates that parameters are integers and within valid ranges (n_warmup >= 0, n_samples >= 1, steps_per_sample >= 1).