### PR TITLE
Fix MomentAccumulatorObserver dtype handling for mixed node types

### DIFF
--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -1,0 +1,34 @@
+import types
+
+import jax
+import jax.numpy as jnp
+
+from thrml.block_management import Block
+from thrml.block_sampling import BlockGibbsSpec
+from thrml.observers import MomentAccumulatorObserver
+from thrml.pgm import CategoricalNode, SpinNode
+
+
+def test_moment_observer_preserves_mixed_node_values():
+    spin = SpinNode()
+    cat = CategoricalNode()
+
+    blocks = [Block([spin]), Block([cat])]
+    node_shape_dtypes = {
+        SpinNode: jax.ShapeDtypeStruct((), jnp.bool_),
+        CategoricalNode: jax.ShapeDtypeStruct((), jnp.uint8),
+    }
+    gibbs_spec = BlockGibbsSpec(blocks, [], node_shape_dtypes)
+    program = types.SimpleNamespace(gibbs_spec=gibbs_spec)
+
+    observer = MomentAccumulatorObserver([[(spin, cat)]])
+    carry = observer.init()
+
+    state_free = [
+        jnp.array([True], dtype=jnp.bool_),
+        jnp.array([2], dtype=jnp.uint8),
+    ]
+
+    carry_out, _ = observer(program, state_free, [], carry, jnp.array(0, dtype=jnp.int32))
+
+    assert carry_out[0][0] == 2


### PR DESCRIPTION
so while logging mixed spin + categorical moments I kept seeing the categorical values get logges as just booleans. looked deeper and learned the MomentAccumulatorObserver was building its flat buffer in the dtype of the first block, so anything non-boolean got truncated

this patch promotes the sampled blocks to a mutual dtype before packing them into the buffer, and adds a regression to reproduce the failure