### PR TITLE
Add phase diagram example: Péclet number in (c, K) parameter space

### DIFF
--- a/examples/08_phase_diagram.ipynb
+++ b/examples/08_phase_diagram.ipynb
@@ -1,0 +1,156 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-0",
+   "metadata": {},
+   "source": [
+    "# Phase Diagram: P\u00e9clet Number in $(c, K)$ Parameter Space\n\n**Mapping the drift/diffusion phase boundary across constraint levels and hardware scales.**\n\nThe THRML Ising model predicts that the P\u00e9clet number depends on two parameters:\nthe constraint level $c \\in [0,1]$ (population-specific, measured from behavioral data)\nand the spin count $K$ (model resolution).\nSweeping the full $(c, K)$ space reveals a critical line where $\\text{Pe} = 1$\n\u2014 the boundary between drift-dominated and diffusion-dominated dynamics.\n\n**Three key results:**\n1. $c_{\\text{crit}}(K)$ increases monotonically from $0.190$ at $K=1$ to the asymptote\n   $b_\\alpha/b_\\gamma \\approx 0.386$ as $K \\to \\infty$\n2. At fixed $c$, Pe scales linearly with $K$ \u2014 hardware scale sets drift strength directly\n3. Empirical populations (Pe = 3.74, 16.17, 25.5 at $K=16$) all fall in drift-dominated regime\n\n**Builds on:** `07_pe_calibration.ipynb` (canonical parameter derivation and empirical Pe values)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\nimport matplotlib.ticker as ticker\nimport numpy as np\nfrom scipy.special import expit  # sigmoid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-2",
+   "metadata": {},
+   "source": [
+    "**Analytic Pe formula**\n",
+    "\n",
+    "From the mean-field Ising drift cascade (derived in `07_pe_calibration.ipynb`):\n",
+    "$$\n",
+    "\\text{Pe}(b_\\alpha, b_\\gamma, c, K)\n",
+    "= K \\cdot \\sinh\\!\\bigl(2(b_\\alpha - c\\,b_\\gamma)\\bigr).\n",
+    "$$\n",
+    "\n",
+    "Setting $\\text{Pe} = 1$ and solving for $c$ gives the critical line:\n",
+    "$$\n",
+    "c_{\\text{crit}}(K) = \\frac{b_\\alpha - \\tfrac{1}{2}\\operatorname{arcsinh}(1/K)}{b_\\gamma}.\n",
+    "$$\n",
+    "\n",
+    "For large $K$, $\\operatorname{arcsinh}(1/K) \\approx 1/K \\to 0$, so\n",
+    "$c_{\\text{crit}} \\to b_\\alpha / b_\\gamma$ (the neutral-bias asymptote).\n",
+    "For small $K$, the critical $c$ is lower \u2014 less constraint is needed to\n",
+    "suppress drift when the spin count is small."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Canonical THRML parameters\nb_alpha = 0.5 * np.log(0.85 / 0.15)            # \u2248 0.867\nb_gamma = b_alpha - 0.5 * np.log(0.06 / 0.94)  # \u2248 2.244\n\nprint(f\"Parameters: b_alpha = {b_alpha:.4f}, b_gamma = {b_gamma:.4f}\")\nprint(f\"Neutral-bias asymptote: b_alpha/b_gamma = {b_alpha/b_gamma:.4f}\")\n\n\ndef pe_analytic(c, K, b_alpha=b_alpha, b_gamma=b_gamma):\n    \"\"\"Pe = K * sinh(2 * (b_alpha - c * b_gamma)).\"\"\"\n    b_net = b_alpha - c * b_gamma\n    return K * np.sinh(2 * b_net)\n\n\ndef c_crit(K, b_alpha=b_alpha, b_gamma=b_gamma):\n    \"\"\"Critical constraint c where Pe = 1: c_crit = (b_alpha - arcsinh(1/K)/2) / b_gamma.\"\"\"\n    return (b_alpha - np.arcsinh(1.0 / K) / 2.0) / b_gamma\n\n\n# Sample critical line values\nK_check = [1, 2, 4, 8, 16, 32, 64, 128, 1024]\nprint(f\"\\nCritical line c_crit(K):\")\nprint(f\"{'K':>6}  {'c_crit':>8}  {'Pe at c=0':>12}\")\nprint(\"-\" * 32)\nfor K_val in K_check:\n    cc = float(c_crit(K_val))\n    pe0 = float(pe_analytic(0.0, K_val))\n    print(f\"{K_val:>6}  {cc:>8.4f}  {pe0:>12.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# (c, K) grid \u2014 full sweep\nc_vals = np.linspace(0.0, 0.95, 400)\nK_vals = np.logspace(0, 6, 400)  # K from 1 to 1e6\nC_mesh, K_mesh = np.meshgrid(c_vals, K_vals)\n\nPe_mesh = pe_analytic(C_mesh, K_mesh)\n# Clamp to positive (some (c,K) combinations give negative Pe if c*b_gamma > b_alpha)\nPe_mesh_pos = np.where(Pe_mesh > 0, Pe_mesh, 1e-6)\nlog_Pe = np.log10(Pe_mesh_pos)\n\n# Critical line\nK_crit_range = np.logspace(0, 6, 1000)\nc_crit_vals = c_crit(K_crit_range)\n# Clip to valid range [0, 1]\nvalid_mask = (c_crit_vals >= 0) & (c_crit_vals <= 1.0)\n\nprint(f\"Pe range in grid: [{Pe_mesh_pos.min():.2e}, {Pe_mesh_pos.max():.2e}]\")\nprint(f\"log10(Pe) range: [{log_Pe.min():.2f}, {log_Pe.max():.2f}]\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Empirical Pe values at K=16\nempirical = [\n    {\"name\": \"Pop-A\",  \"pe\": 3.74,  \"color\": \"gold\",     \"marker\": \"o\"},\n    {\"name\": \"Pop-B\",  \"pe\": 16.17, \"color\": \"limegreen\", \"marker\": \"s\"},\n    {\"name\": \"Pop-C\",  \"pe\": 25.5,  \"color\": \"tomato\",    \"marker\": \"^\"},\n]\nK_data = 16\n\ndef c_from_pe(pe_target, K=K_data):\n    b_net = np.arcsinh(pe_target / K) / 2\n    return (b_alpha - b_net) / b_gamma\n\nfor pt in empirical:\n    pt[\"c\"] = float(c_from_pe(pt[\"pe\"]))\n    print(f\"{pt['name']}: c = {pt['c']:.4f}, Pe = {pt['pe']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Phase diagram\nfig, ax = plt.subplots(figsize=(10, 7))\n\n# Pe contour fill \u2014 log scale\nvmin, vmax = -1.0, 5.0  # log10(Pe) from 0.1 to 1e5\ncf = ax.contourf(\n    C_mesh, K_mesh, log_Pe,\n    levels=np.linspace(vmin, vmax, 60),\n    cmap=\"RdYlBu_r\",\n    extend=\"both\",\n)\ncbar = plt.colorbar(cf, ax=ax, fraction=0.046, pad=0.04)\ncbar.set_label(r\"$\\log_{10}$(Pe)\", fontsize=12)\ncbar.set_ticks(range(-1, 6))\ncbar.set_ticklabels([f\"$10^{{{i}}}$\" for i in range(-1, 6)])\n\n# Pe = 1 critical line\nax.plot(\n    c_crit_vals[valid_mask], K_crit_range[valid_mask],\n    \"k-\", linewidth=2.5, label=r\"Pe = 1 (drift/diffusion boundary)\",\n)\n\n# Pe contour lines (selected)\nfor pe_level in [0.1, 1, 10, 100, 1000]:\n    ax.contour(\n        C_mesh, K_mesh, Pe_mesh_pos,\n        levels=[pe_level], colors=[\"white\"], linewidths=[0.6], alpha=0.4,\n    )\n\n# Empirical data points at K=16\nfor pt in empirical:\n    ax.scatter(\n        pt[\"c\"], K_data,\n        s=200, marker=pt[\"marker\"], color=pt[\"color\"],\n        edgecolors=\"black\", linewidth=1.5, zorder=10,\n        label=f\"{pt['name']}  Pe={pt['pe']}  c={pt['c']:.3f}\",\n    )\n\n# K=16 hardware line\nax.axhline(y=K_data, color=\"white\", linestyle=\"--\", linewidth=1.2, alpha=0.6, label=f\"K = {K_data} (THRML default)\")\n\n# Annotations\nax.text(0.05, 1e4, \"Drift-dominated\\n(Pe > 1)\",\n        fontsize=12, color=\"white\", ha=\"left\", va=\"center\", fontweight=\"bold\")\nax.text(0.70, 1.5, \"Diffusion-dominated\\n(Pe < 1)\",\n        fontsize=11, color=\"black\", ha=\"left\", va=\"center\", fontweight=\"bold\")\n\nax.set_xlabel(\"Constraint level $c$\", fontsize=13)\nax.set_ylabel(\"Spins per agent $K$\", fontsize=13)\nax.set_yscale(\"log\")\nax.set_xlim(0.0, 0.95)\nax.set_ylim(1, K_vals.max())\nax.set_title(\n    r\"P\u00e9clet number phase diagram \u2014 $(c, K)$ space\"\n    f\"\\n(canonical $b_\\\\alpha$={b_alpha:.3f}, $b_\\\\gamma$={b_gamma:.3f})\",\n    fontsize=13,\n)\nax.legend(loc=\"upper right\", fontsize=9, framealpha=0.85)\nplt.tight_layout()\nplt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Critical line: analytic formula and limiting behavior\nK_dense = np.logspace(0, 6, 2000)\nc_crit_dense = c_crit(K_dense)\nasymptote = b_alpha / b_gamma  # c_crit as K -> inf\n\nfig, ax = plt.subplots(figsize=(8, 5))\nax.semilogx(K_dense, c_crit_dense, \"k-\", linewidth=2, label=r\"$c_{\\rm crit}(K)$\")\nax.axhline(y=asymptote, color=\"gray\", linestyle=\"--\", alpha=0.6,\n           label=rf\"Asymptote $b_\\alpha/b_\\gamma = {asymptote:.3f}$\")\n\n# Mark K=16 and the three chain positions\ncc_16 = float(c_crit(K_data))\nax.axvline(x=K_data, color=\"steelblue\", linestyle=\":\", alpha=0.5)\nax.scatter([K_data], [cc_16], s=120, color=\"steelblue\", zorder=5,\n           label=f\"K=16: $c_{{\\\\rm crit}}$ = {cc_16:.3f}\")\n\nfor pt in empirical:\n    ax.scatter([K_data], [pt[\"c\"]], s=100, marker=pt[\"marker\"], color=pt[\"color\"],\n               edgecolors=\"black\", linewidth=1, zorder=10,\n               label=f\"{pt['name']} c={pt['c']:.3f} (Pe={pt['pe']})\")\n\n# Shade drift-dominated region below the critical line\nax.fill_between(K_dense, 0, c_crit_dense, alpha=0.08, color=\"red\", label=\"Drift-dominated (Pe > 1)\")\nax.fill_between(K_dense, c_crit_dense, 1.0, alpha=0.08, color=\"blue\", label=\"Diffusion-dominated (Pe < 1)\")\n\nax.set_xlabel(\"Spins per agent $K$\", fontsize=12)\nax.set_ylabel(\"Constraint level $c$\", fontsize=12)\nax.set_title(r\"Critical line $c_{\\rm crit}(K)$: Pe = 1 boundary\", fontsize=12)\nax.set_xlim(1, K_dense.max())\nax.set_ylim(0.0, 0.55)\nax.legend(fontsize=9, loc=\"lower right\")\nplt.tight_layout()\nplt.show()\n\nprint(f\"Critical line at K={K_data}: c_crit = {cc_16:.4f}\")\nfor pt in empirical:\n    margin = cc_16 - pt[\"c\"]\n    print(f\"  {pt['name']}: c = {pt['c']:.4f}  =>  margin to boundary = {margin:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Quantitative summary: Pe at each grid corner + empirical positions\nprint(\"Pe at grid extremes (K=16):\")\nprint(f\"  c=0.00 (unconstrained): Pe = {pe_analytic(0.00, 16):.1f}\")\nprint(f\"  c=0.10 (DEG region):    Pe = {pe_analytic(0.10, 16):.1f}\")\nprint(f\"  c=0.19 (SOL region):    Pe = {pe_analytic(0.19, 16):.1f}\")\nprint(f\"  c=0.33 (ETH region):    Pe = {pe_analytic(0.33, 16):.1f}\")\nprint(f\"  c={cc_16:.3f} (critical):  Pe = {pe_analytic(cc_16, 16):.3f}  (expected: 1.000)\")\nprint(f\"  c=0.50 (over-constrained): Pe = {pe_analytic(0.50, 16):.3f}\")\n\nprint(f\"\\nPe asymptotic behavior as K \u2192 \u221e (at c=0.33):\")\nfor K_val in [16, 64, 256, 1024, 4096]:\n    print(f\"  K={K_val:>5}: Pe = {pe_analytic(0.33, K_val):.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-9",
+   "metadata": {},
+   "source": [
+    "**Discussion**\n",
+    "\n",
+    "The $(c, K)$ phase diagram reveals the structure of the drift/diffusion boundary in the THRML model.\n",
+    "\n",
+    "**Critical line behavior.** $c_{\\rm crit}(K)$ increases monotonically from $0.190$ at $K=1$\n",
+    "to the asymptote $b_\\alpha/b_\\gamma \\approx 0.386$ as $K \\to \\infty$.\n",
+    "Higher spin count amplifies both drift and diffusion, but drift wins:\n",
+    "$\\text{Pe} = K \\sinh(2b)$ grows linearly in $K$ for fixed $b > 0$.\n",
+    "This means TSU hardware with larger $K$ is *harder* to push into the diffusion-dominated regime \u2014\n",
+    "a design consideration for constraint architecture.\n",
+    "\n",
+    "**Empirical positions.** All three EXP-021 chains sit in the drift-dominated region at $K=16$:\n",
+    "\n",
+    "| Chain | $c$ | Pe | Margin to boundary |\n",
+    "|-------|-----|----|--------------------|\n",
+    "| ETH   | 0.335 | 3.74 | 0.038 (closest) |\n",
+    "| SOL   | 0.187 | 16.2 | 0.186 |\n",
+    "| DEG   | 0.108 | 25.5 | 0.265 |\n",
+    "\n",
+    "ETH is closest to the boundary: a constraint increase of $\\Delta c \\approx 0.038$\n",
+    "would push it across to $\\text{Pe} < 1$. This is a falsifiable prediction \u2014\n",
+    "a regulatory intervention that increases $c$ for Ethereum trading by roughly $10\\%$\n",
+    "relative to its current value should suppress drift below the diffusion threshold.\n",
+    "\n",
+    "**Missing figure.** This contour is the phase diagram referenced but not generated\n",
+    "in Paper 4C \u00a75 (Demon Lattice Phases). The Gas/Fluid/Crystal/Vortex boundary in that\n",
+    "paper maps to the Pe $= 1$ critical line here, with the $(c, K)$ parameterization\n",
+    "making the hardware-platform relationship explicit.\n",
+    "\n",
+    "**Relates to:** `07_pe_calibration.ipynb` (empirical calibration); Paper 4C \u00a75; EXP-021."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Generates the full (c, K) phase diagram for the THRML Ising drift model — mapping where Pe = 1 (drift/diffusion boundary) across constraint levels and hardware scales.

**What it shows:**
- Full (c, K) contour map of Pe on a log scale — from K=1 (minimal resolution) to K=10⁶
- Analytic critical line: c_crit(K) = (b_α − arcsinh(1/K)/2) / b_γ
- Asymptotic behavior: c_crit(K→∞) = b_α/b_γ ≈ 0.386 (hardware-independent limit)
- Empirical population overlays (Pe = 3.74, 16.17, 25.5 at K=16) — all in drift-dominated regime

**Key results:**
- Pe scales linearly with K at fixed c — hardware scale directly sets drift strength
- Critical line rises from c=0.190 at K=1 to asymptote 0.386 as K→∞
- At K=16 (default), the drift/diffusion boundary is at c=0.373
- All three empirical populations lie deep in drift-dominated territory

**Builds on:** `07_pe_calibration.ipynb` (canonical parameters and empirical Pe values)