### PR TITLE
Bug: empty free variables in positive phase results in index error

### DIFF
--- a/tests/test_ising.py
+++ b/tests/test_ising.py
@@ -2,6 +2,7 @@ import unittest
 
 import equinox as eqx
 import jax
+import networkx as nx
 from jax import numpy as jnp
 
 from thrml.block_management import Block
@@ -204,11 +205,9 @@ class TestEstimateKLGrad(unittest.TestCase):
 
 
 class TestEstimateKLGradFullyVisible(unittest.TestCase):
-    """Test that estimate_kl_grad works when all nodes are visible (no latent variables)."""
+    """Test that estimate_kl_grad works when all nodes are visible."""
 
     def test_fully_visible_ising(self):
-        import networkx as nx
-
         key = jax.random.key(0)
 
         G = nx.grid_2d_graph(4, 4)
@@ -247,7 +246,7 @@ class TestEstimateKLGradFullyVisible(unittest.TestCase):
         init_free = hinton_init(subkey, model, free_blocks, (batch_size,))
 
         key, subkey = jax.random.split(key)
-        grad_w, grad_b, _, _ = estimate_kl_grad(
+        grad_w, grad_b, (moms_b_pos, _), _ = estimate_kl_grad(
             subkey,
             training_spec,
             nodes,
@@ -263,3 +262,7 @@ class TestEstimateKLGradFullyVisible(unittest.TestCase):
         self.assertEqual(grad_b.shape, (16,))
         self.assertTrue(jnp.all(jnp.isfinite(grad_w)))
         self.assertTrue(jnp.all(jnp.isfinite(grad_b)))
+
+        # Positive-phase bias moments should be exactly the data spins (no sampling occurs)
+        expected_spins = 2 * data.astype(moms_b_pos.dtype) - 1
+        self.assertTrue(jnp.allclose(moms_b_pos[0], expected_spins))

--- a/tests/test_ising.py
+++ b/tests/test_ising.py
@@ -201,3 +201,65 @@ class TestEstimateKLGrad(unittest.TestCase):
 
         self.assertLess(error_w, 0.01)
         self.assertLess(error_b, 0.01)
+
+
+class TestEstimateKLGradFullyVisible(unittest.TestCase):
+    """Test that estimate_kl_grad works when all nodes are visible (no latent variables)."""
+
+    def test_fully_visible_ising(self):
+        import networkx as nx
+
+        key = jax.random.key(0)
+
+        G = nx.grid_2d_graph(4, 4)
+        nodes = [SpinNode() for _ in range(16)]
+        G = nx.relabel_nodes(G, {coord: nodes[i] for i, coord in enumerate(G.nodes)})
+        edges = list(G.edges)
+
+        model = IsingEBM(
+            nodes,
+            edges,
+            biases=jax.random.normal(key, (16,)),
+            weights=jax.random.normal(key, (len(edges),)),
+            beta=jnp.array(1.0),
+        )
+
+        coloring = nx.coloring.greedy_color(G, strategy="DSATUR")
+        free_blocks = [
+            Block([n for n, c in coloring.items() if c == color]) for color in range(max(coloring.values()) + 1)
+        ]
+
+        training_spec = IsingTrainingSpec(
+            model,
+            data_blocks=[Block(nodes)],
+            conditioning_blocks=[],
+            positive_sampling_blocks=[],
+            negative_sampling_blocks=free_blocks,
+            schedule_positive=SamplingSchedule(n_warmup=0, n_samples=1, steps_per_sample=0),
+            schedule_negative=SamplingSchedule(n_warmup=0, n_samples=1, steps_per_sample=1),
+        )
+
+        batch_size = 32
+        key, subkey = jax.random.split(key)
+        data = jax.random.bernoulli(subkey, 0.5, (batch_size, 16)).astype(jnp.bool_)
+
+        key, subkey = jax.random.split(key)
+        init_free = hinton_init(subkey, model, free_blocks, (batch_size,))
+
+        key, subkey = jax.random.split(key)
+        grad_w, grad_b, _, _ = estimate_kl_grad(
+            subkey,
+            training_spec,
+            nodes,
+            edges,
+            [data],
+            [],
+            [],
+            init_free,
+        )
+
+        # Gradients should be finite and have correct shapes
+        self.assertEqual(grad_w.shape, (len(edges),))
+        self.assertEqual(grad_b.shape, (16,))
+        self.assertTrue(jnp.all(jnp.isfinite(grad_w)))
+        self.assertTrue(jnp.all(jnp.isfinite(grad_b)))

--- a/thrml/models/ising.py
+++ b/thrml/models/ising.py
@@ -266,16 +266,16 @@ def estimate_kl_grad(
     if len(init_state_positive) == 0:
         # if there are no initial states in pos sampling
         # data[0]: (batch, n_nodes)
-        spins = 2 * data[0].astype(float_type) - 1          # (batch, n_nodes)
+        spins = 2 * data[0].astype(float_type) - 1  # (batch, n_nodes)
 
         ei_idx = jnp.array([bias_nodes.index(e[0]) for e in weight_edges])  # (n_edges,)
         ej_idx = jnp.array([bias_nodes.index(e[1]) for e in weight_edges])  # (n_edges,)
 
-        moms_b_pos = spins                                   # (batch, n_nodes)
-        moms_w_pos = spins[:, ei_idx] * spins[:, ej_idx]     # (batch, n_edges)
+        moms_b_pos = spins  # (batch, n_nodes)
+        moms_w_pos = spins[:, ei_idx] * spins[:, ej_idx]  # (batch, n_edges)
 
-        moms_b_pos = moms_b_pos[None]                        # (1, batch, n_nodes)
-        moms_w_pos = moms_w_pos[None]                        # (1, batch, n_edges)
+        moms_b_pos = moms_b_pos[None]  # (1, batch, n_nodes)
+        moms_w_pos = moms_w_pos[None]  # (1, batch, n_edges)
     else:
         keys_pos = jax.random.split(key_pos, init_state_positive[0].shape[:2])
         moms_b_pos, moms_w_pos = jax.vmap(
@@ -299,7 +299,6 @@ def estimate_kl_grad(
             conditioning_values,
         )
     )(keys_neg, init_state_negative)
-
 
     grad_b = -training_spec.ebm.beta * (
         jnp.mean(moms_b_pos, axis=(0, 1), dtype=float_type) - jnp.mean(moms_b_neg, axis=0, dtype=float_type)

--- a/thrml/models/ising.py
+++ b/thrml/models/ising.py
@@ -258,19 +258,33 @@ def estimate_kl_grad(
         the weight gradients and the bias gradients
     """
 
+    float_type = training_spec.ebm.beta.dtype
     key_pos, key_neg = jax.random.split(key, 2)
 
     cond_batched_pos = jax.tree.map(lambda x: jnp.broadcast_to(x, (data[0].shape[0], *x.shape)), conditioning_values)
 
-    keys_pos = jax.random.split(key_pos, init_state_positive[0].shape[:2])
+    if len(init_state_positive) == 0:
+        # if there are no initial states in pos sampling
+        # data[0]: (batch, n_nodes)
+        spins = 2 * data[0].astype(float_type) - 1          # (batch, n_nodes)
 
-    moms_b_pos, moms_w_pos = jax.vmap(
-        lambda k_out, i_out: jax.vmap(
-            lambda k, i, c: estimate_moments(
-                k, bias_nodes, weight_edges, training_spec.program_positive, training_spec.schedule_positive, i, c
-            )
-        )(k_out, i_out, data + cond_batched_pos)
-    )(keys_pos, init_state_positive)
+        ei_idx = jnp.array([bias_nodes.index(e[0]) for e in weight_edges])  # (n_edges,)
+        ej_idx = jnp.array([bias_nodes.index(e[1]) for e in weight_edges])  # (n_edges,)
+
+        moms_b_pos = spins                                   # (batch, n_nodes)
+        moms_w_pos = spins[:, ei_idx] * spins[:, ej_idx]     # (batch, n_edges)
+
+        moms_b_pos = moms_b_pos[None]                        # (1, batch, n_nodes)
+        moms_w_pos = moms_w_pos[None]                        # (1, batch, n_edges)
+    else:
+        keys_pos = jax.random.split(key_pos, init_state_positive[0].shape[:2])
+        moms_b_pos, moms_w_pos = jax.vmap(
+            lambda k_out, i_out: jax.vmap(
+                lambda k, i, c: estimate_moments(
+                    k, bias_nodes, weight_edges, training_spec.program_positive, training_spec.schedule_positive, i, c
+                )
+            )(k_out, i_out, data + cond_batched_pos)
+        )(keys_pos, init_state_positive)
 
     keys_neg = jax.random.split(key_neg, init_state_negative[0].shape[0])
 
@@ -286,7 +300,7 @@ def estimate_kl_grad(
         )
     )(keys_neg, init_state_negative)
 
-    float_type = training_spec.ebm.beta.dtype
+
     grad_b = -training_spec.ebm.beta * (
         jnp.mean(moms_b_pos, axis=(0, 1), dtype=float_type) - jnp.mean(moms_b_neg, axis=0, dtype=float_type)
     )


### PR DESCRIPTION

### Summary

If there are no hidden nodes, or all variables are clamped during the positive phase, `estimate_kl_grad` does not handle this edge case. Specifically, in the below contrastive divergence gradient

$$
    \underbrace{ \mathbb{E}_{p_\text{data}} [\nabla_\theta \mathcal{E}_\theta (x)] }_\text{positive phase} - 
    \underbrace{
        \mathbb{E}_{p_\theta} [\nabla_\theta \mathcal{E}_\theta (x)] }_\text{negative phase}
$$

`thrml` does not handle the case where $x$ is entirely visible and clamped to $x \sim p_\text{data}$. `estimate_kl_grad` implicitly assumes there are always free variables in the `init_positive`, by subindexing the list to create keys for sampling.

```python
keys_pos = jax.random.split(key_pos, init_state_positive[0].shape[:2])

moms_b_pos, moms_w_pos = jax.vmap(
    lambda k_out, i_out: jax.vmap(
        lambda k, i, c: estimate_moments(
            k, bias_nodes, weight_edges, training_spec.program_positive, training_spec.schedule_positive, i, c
        )
    )(k_out, i_out, data + cond_batched_pos)
)(keys_pos, init_state_positive)
```
This throws the expected `IndexError`



### Minimal reproduction

```python
import jax
import jax.numpy as jnp
import networkx as nx
from thrml.pgm import SpinNode
from thrml.models.ising import (
    IsingEBM, IsingTrainingSpec, estimate_kl_grad, hinton_init
)
from thrml.block_management import Block
from thrml.block_sampling import SamplingSchedule

G = nx.grid_2d_graph(4, 4)
nodes = [SpinNode() for _ in range(16)]
G = nx.relabel_nodes(G, {coord: nodes[i] for i, coord in enumerate(G.nodes)})
edges = list(G.edges)

key = jax.random.key(0)
model = IsingEBM(
    nodes, edges,
    biases=jax.random.normal(key, (16,)),
    weights=jax.random.normal(key, (len(edges),)),
    beta=jnp.array(1.0),
)

coloring = nx.coloring.greedy_color(G, strategy="DSATUR")
free_blocks = [
    Block([n for n, c in coloring.items() if c == color])
    for color in range(max(coloring.values()) + 1)
]

training_spec = IsingTrainingSpec(
    model,
    data_blocks=[Block(nodes)],
    conditioning_blocks=[],
    positive_sampling_blocks=[],
    negative_sampling_blocks=free_blocks,
    schedule_positive=SamplingSchedule(n_warmup=0, n_samples=1, steps_per_sample=0),
    schedule_negative=SamplingSchedule(n_warmup=0, n_samples=1, steps_per_sample=1),
)

batch_size = 32
data = jax.random.bernoulli(key, 0.5, (batch_size, 16)).astype(jnp.bool_)
init_free = hinton_init(key, model, free_blocks, (batch_size,))

# Crashes: IndexError: list index out of range
estimate_kl_grad(key, training_spec, nodes, edges, [data], [], [], init_free)
```

### Fix: explicitly handle this case in `estimate_kl_grad`

```python
if len(init_state_positive) == 0:
    # if there are no initial states in pos sampling
    # data[0]: (batch, n_nodes)
    spins = 2 * data[0].astype(float_type) - 1          # (batch, n_nodes)

    ei_idx = jnp.array([bias_nodes.index(e[0]) for e in weight_edges])  # (n_edges,)
    ej_idx = jnp.array([bias_nodes.index(e[1]) for e in weight_edges])  # (n_edges,)

    moms_b_pos = spins                                   # (batch, n_nodes)
    moms_w_pos = spins[:, ei_idx] * spins[:, ej_idx]     # (batch, n_edges)

    moms_b_pos = moms_b_pos[None]                        # (1, batch, n_nodes)
    moms_w_pos = moms_w_pos[None]                        # (1, batch, n_edges)
else:
    keys_pos = jax.random.split(key_pos, init_state_positive[0].shape[:2])
    moms_b_pos, moms_w_pos = jax.vmap(
        lambda k_out, i_out: jax.vmap(
            lambda k, i, c: estimate_moments(
                k, bias_nodes, weight_edges, training_spec.program_positive, training_spec.schedule_positive, i, c
            )
        )(k_out, i_out, data + cond_batched_pos)
    )(keys_pos, init_state_positive)
```

### Comments

Let me know if there's a more logical way of handling the shapes, or to set `moms_b_pos, moms_w_pos` to match the previous semantics