### PR TITLE
Fix the README logo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="docs/_static/logo/logo.svg" alt="THRML Logo" width="150" style="margin-bottom: 10px;">
+  <img src="docs_site/brand/logo.svg" alt="THRML Logo" width="150" style="margin-bottom: 10px;">
 </div>
 
 <h1 align='center'>THRML</h1>


### PR DESCRIPTION
PR #44 moved the logo from docs/_static/logo/logo.svg to docs_site/brand/logo.svg but the README still pointed at the old path, so the logo on the repo front page was broken. Updated the img src to the new location.