### PR TITLE
Switch the wordmark to Chakra Petch

### DIFF
--- a/docs_site/scripts/assets/index.css
+++ b/docs_site/scripts/assets/index.css
@@ -1,5 +1,6 @@
 @font-face { font-family: "Kessler Display W"; src: url(ASSET_BASE/fonts/kessler-display-italic.woff2) format("woff2"); font-weight: 400; font-style: italic; font-display: swap; }
 @font-face { font-family: "Rephlex Trial"; src: url(ASSET_BASE/fonts/rephlex-regular.woff2) format("woff2"); font-weight: 400; font-style: normal; font-display: swap; }
+@font-face { font-family: "Chakra Petch"; src: url(ASSET_BASE/fonts/chakra-petch-bold.woff2) format("woff2"); font-weight: 700; font-style: normal; font-display: swap; }
 @font-face { font-family: "Suisse BP Int'l"; src: url(ASSET_BASE/fonts/suisse-intl-regular.woff2) format("woff2"); font-weight: 400; font-style: normal; font-display: swap; }
 @font-face { font-family: "Suisse BP Int'l"; src: url(ASSET_BASE/fonts/suisse-intl-medium.woff2) format("woff2"); font-weight: 500; font-style: normal; font-display: swap; }
 @font-face { font-family: "Suisse BP Int'l"; src: url(ASSET_BASE/fonts/suisse-intl-bold.woff2) format("woff2"); font-weight: 700; font-style: normal; font-display: swap; }
@@ -11,7 +12,7 @@
   --mono: "Suisse Int'l Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   --display: "Kessler Display W", Georgia, "Times New Roman", serif;
   --body-sans: "Suisse BP Int'l", -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
-  --wordmark: "Rephlex Trial", "Suisse BP Int'l", Arial, sans-serif;
+  --wordmark: "Chakra Petch", "Suisse BP Int'l", Arial, sans-serif;
   color-scheme: dark;
 }
 * { box-sizing: border-box; }

--- a/docs_site/scripts/assets/notebook.css
+++ b/docs_site/scripts/assets/notebook.css
@@ -3,6 +3,7 @@
    Suisse BP Int'l for body, Suisse Int'l Mono for code/UI, Rephlex for the wordmark. */
 @font-face { font-family: "Kessler Display W"; src: url(ASSET_BASE/fonts/kessler-display-italic.woff2) format("woff2"); font-weight: 400; font-style: italic; font-display: swap; }
 @font-face { font-family: "Rephlex Trial"; src: url(ASSET_BASE/fonts/rephlex-regular.woff2) format("woff2"); font-weight: 400; font-style: normal; font-display: swap; }
+@font-face { font-family: "Chakra Petch"; src: url(ASSET_BASE/fonts/chakra-petch-bold.woff2) format("woff2"); font-weight: 700; font-style: normal; font-display: swap; }
 @font-face { font-family: "Suisse BP Int'l"; src: url(ASSET_BASE/fonts/suisse-intl-regular.woff2) format("woff2"); font-weight: 400; font-style: normal; font-display: swap; }
 @font-face { font-family: "Suisse BP Int'l"; src: url(ASSET_BASE/fonts/suisse-intl-medium.woff2) format("woff2"); font-weight: 500; font-style: normal; font-display: swap; }
 @font-face { font-family: "Suisse BP Int'l"; src: url(ASSET_BASE/fonts/suisse-intl-bold.woff2) format("woff2"); font-weight: 700; font-style: normal; font-display: swap; }
@@ -291,7 +292,7 @@ mjx-container[display="true"] svg, mjx-container[display="true"] svg * { fill: v
   35% { color: #F5D64C; filter: drop-shadow(0 0 7px rgba(245,214,76,.75)); }
   70% { color: #FF8400; filter: drop-shadow(0 0 9px rgba(255,132,0,.55)); }
 }
-.thrml-topbar .thrml-title { font-family: "Rephlex Trial", "Suisse BP Int'l", sans-serif; font-size: 17px;
+.thrml-topbar .thrml-title { font-family: "Chakra Petch", "Suisse BP Int'l", sans-serif; font-size: 17px;
   letter-spacing: 0.12em; color: var(--ex-cream); }
 .thrml-topbar .thrml-pills { display: flex; gap: 8px; }
 .thrml-topbar .thrml-pill { display: inline-flex; align-items: center; font-size: 10.5px; letter-spacing: -0.01em;

--- a/docs_site/static/paper.html
+++ b/docs_site/static/paper.html
@@ -12,6 +12,7 @@
      Suisse BP Int'l for body, Suisse Int'l Mono for code/UI, Rephlex for the wordmark. */
   @font-face { font-family: "Kessler Display W"; src: url(https://thrml-docs.vercel.app/fonts/kessler-display-italic.woff2) format("woff2"); font-weight: 400; font-style: italic; font-display: swap; }
   @font-face { font-family: "Rephlex Trial"; src: url(https://thrml-docs.vercel.app/fonts/rephlex-regular.woff2) format("woff2"); font-weight: 400; font-style: normal; font-display: swap; }
+  @font-face { font-family: "Chakra Petch"; src: url(https://thrml-docs.vercel.app/fonts/chakra-petch-bold.woff2) format("woff2"); font-weight: 700; font-style: normal; font-display: swap; }
   @font-face { font-family: "Suisse BP Int'l"; src: url(https://thrml-docs.vercel.app/fonts/suisse-intl-regular.woff2) format("woff2"); font-weight: 400; font-style: normal; font-display: swap; }
   @font-face { font-family: "Suisse BP Int'l"; src: url(https://thrml-docs.vercel.app/fonts/suisse-intl-medium.woff2) format("woff2"); font-weight: 500; font-style: normal; font-display: swap; }
   @font-face { font-family: "Suisse BP Int'l"; src: url(https://thrml-docs.vercel.app/fonts/suisse-intl-bold.woff2) format("woff2"); font-weight: 700; font-style: normal; font-display: swap; }
@@ -300,7 +301,7 @@
     35% { color: #F5D64C; filter: drop-shadow(0 0 7px rgba(245,214,76,.75)); }
     70% { color: #FF8400; filter: drop-shadow(0 0 9px rgba(255,132,0,.55)); }
   }
-  .thrml-topbar .thrml-title { font-family: "Rephlex Trial", "Suisse BP Int'l", sans-serif; font-size: 17px;
+  .thrml-topbar .thrml-title { font-family: "Chakra Petch", "Suisse BP Int'l", sans-serif; font-size: 17px;
     letter-spacing: 0.12em; color: var(--ex-cream); }
   .thrml-topbar .thrml-pills { display: flex; gap: 8px; }
   .thrml-topbar .thrml-pill { display: inline-flex; align-items: center; font-size: 10.5px; letter-spacing: -0.01em;


### PR DESCRIPTION
Moves the THRML wordmark from Rephlex to Chakra Petch across the docs: the top-bar wordmark on every page and the landing-page brand. Chakra Petch is a sharper, angular face that pairs better with the geometric logo than the rounded Rephlex.

Adds a self-hosted @font-face for chakra-petch-bold.woff2 (served from the asset CDN alongside the other brand fonts) and repoints `--wordmark` and `.thrml-title`, including the standalone paper page's inline styles.