### PR TITLE
docs: fix paper button link (resolve under /en/latest/)

### DIFF
--- a/docs_site/scripts/thrml_render/chrome.py
+++ b/docs_site/scripts/thrml_render/chrome.py
@@ -27,7 +27,7 @@ def build_topbar():
         '<nav class="thrml-pills">'
         '<a class="thrml-pill" href="getting-started.html">Get started</a>'
         '<a class="thrml-pill" href="examples.html">Examples</a>'
-        '<a class="thrml-pill" href="/papers/codon-optimization">Paper</a>'
+        '<a class="thrml-pill" href="papers/codon-optimization/">Paper</a>'
         '<a class="thrml-pill" href="' + INDEX_GITHUB + '">GitHub</a>'
         "</nav></header>"
     )

--- a/docs_site/scripts/thrml_render/pages.py
+++ b/docs_site/scripts/thrml_render/pages.py
@@ -333,7 +333,7 @@ def write_index(entries):
     <nav class="pills">
       <a class="pill" href="getting-started.html">Docs</a>
       <a class="pill" href="examples.html">Examples</a>
-      <a class="pill" href="/papers/codon-optimization">Paper</a>
+      <a class="pill" href="papers/codon-optimization/">Paper</a>
       <a class="pill" href="{INDEX_GITHUB}">GitHub</a>
     </nav>
   </header>
@@ -392,7 +392,7 @@ def write_index(entries):
       </a>
     </div>
     <div class="apps-links">
-      <a class="browse" href="/papers/codon-optimization">Read the paper &rarr;</a>
+      <a class="browse" href="papers/codon-optimization/">Read the paper &rarr;</a>
       <a class="browse" href="https://github.com/extropic-ai/codon_opt">Reproduction code on GitHub &rarr;</a>
     </div>
   </section>


### PR DESCRIPTION
The paper nav links were root-absolute (`/papers/codon-optimization`), which 404s on docs.thrml.ai because Read the Docs serves the site under an `/en/latest/` prefix. Switch them to relative (`papers/codon-optimization/`) so they resolve to the working `/en/latest/papers/codon-optimization/`. Minimal change, nothing else touched.