### PR TITLE
docs: bring the docs renderer to the package quality bar (+ API members)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Build docs
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+jobs:
+  docs-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install
+        run: pip install -e .[docs] pytest
+      - name: Build the docs site (smoke check)
+        run: python docs_site/scripts/render_html.py
+      - name: Run the docs render tests
+        run: python -m pytest docs_site/tests/test_docs_render.py -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,5 +19,5 @@ repos:
     rev: v1.1.408
     hooks:
     - id: pyright
-      additional_dependencies: [equinox, jaxtyping]
-      files: thrml/
+      additional_dependencies: [equinox, jaxtyping, nbformat, nbconvert]
+      files: ^(thrml/|docs_site/scripts/)

--- a/docs_site/scripts/assets/docs.css
+++ b/docs_site/scripts/assets/docs.css
@@ -73,6 +73,11 @@ a.api-xref-plain { color: inherit; text-decoration: none; border-bottom: 1px dot
 a.api-xref-plain:hover { color: var(--ex-orange); border-bottom-color: var(--ex-orange); }
 .api-sig a.api-xref-plain { color: var(--ex-cream); }
 .api-doc > p:first-child { color: var(--ex-cream); }
+/* Per-class member cards (methods, properties, attributes), indented under the class. */
+.api-members { margin: 1.4rem 0 0; padding-left: 1.1rem; border-left: 1px solid var(--ex-rule); }
+.api-member { margin: 0 0 1.6rem; }
+.api-member:last-child { margin-bottom: 0; }
+.api-member .api-name { font-size: 1.05rem; }
 .api-disp { margin: 1.1rem 0; overflow-x: auto; color: var(--ex-cream); }
 .thrml-doc mjx-container { color: var(--ex-cream); }
 .thrml-doc mjx-container[display="true"] { margin: 1rem 0 !important; }

--- a/docs_site/scripts/render_html.py
+++ b/docs_site/scripts/render_html.py
@@ -25,7 +25,7 @@ import html as html_lib
 import shutil
 
 import nbformat
-from thrml_render.api_reference import api_inner, linkify_api
+from thrml_render.api_reference import api_inner, linkify_api, validate_api_reference
 from thrml_render.chrome import (
     fix_known_links,
     inject_chrome,
@@ -41,6 +41,7 @@ from thrml_render.config import (
     ROOT,
     SKIP_RENDER,
     STATIC_DIR,
+    validate_notebook_catalog,
 )
 from thrml_render.notebooks import (
     build_exporter,
@@ -58,10 +59,19 @@ from thrml_render.pages import (
 )
 
 
+def _fail_if_errors(errors, label):
+    if errors:
+        joined = "\n".join(f"- {error}" for error in errors)
+        raise RuntimeError(f"{label} failed:\n{joined}")
+
+
 def copy_static():
     """Copy the file-backed assets the pages reference into rendered/."""
     FIG_DIR.mkdir(parents=True, exist_ok=True)
-    # Figures committed beside notebooks or in the brand dir.
+    # Figures committed beside notebooks or in the brand dir. The brand images
+    # (flow.png, extropic_wordmark.png) are licensed assets served from the CDN
+    # and intentionally absent from this public repo, so a missing source is
+    # skipped here (not a build error); the deploy mirror supplies them.
     for src, dst in [
         (NB_DIR / "fps.png", FIG_DIR / "fps.png"),
         (NB_DIR / "codon_pipeline.png", FIG_DIR / "codon_pipeline.png"),
@@ -82,6 +92,9 @@ def copy_static():
 
 def main():
     OUT_DIR.mkdir(exist_ok=True)
+    # Fail loudly on a notebook/catalog mismatch; warn (don't fail) on API drift.
+    _fail_if_errors(validate_notebook_catalog(), "notebook catalog validation")
+    validate_api_reference()
     copy_static()
     exporter = build_exporter()
 

--- a/docs_site/scripts/render_html.py
+++ b/docs_site/scripts/render_html.py
@@ -57,6 +57,7 @@ from thrml_render.pages import (
     write_index,
     write_llms_txt,
 )
+from thrml_render.text import replace_once
 
 
 def _fail_if_errors(errors, label):
@@ -113,10 +114,11 @@ def main():
     for path, nb, _number, title in notebooks:
         tag_hidden_inputs(nb)
         body, _ = exporter.from_notebook_node(nb)
-        body = body.replace(
+        body = replace_once(
+            body,
             "<title>Notebook</title>",
             f"<title>{html_lib.escape(title)} &middot; THRML</title>",
-            1,
+            "notebook title marker",
         )
         body = externalize_images(body, path.stem)
         body = rewrite_local_images(body)

--- a/docs_site/scripts/thrml_render/api_reference.py
+++ b/docs_site/scripts/thrml_render/api_reference.py
@@ -8,8 +8,6 @@ absent from its module is skipped with a warning, so a thrml API change never
 silently drops a symbol from the docs.
 """
 
-from __future__ import annotations
-
 import functools
 import html as html_lib
 import importlib
@@ -221,8 +219,13 @@ def render_docstring(doc):
     return res
 
 
-def _member_target(static: object) -> typing.Any:
-    """Unwrap a descriptor to the callable that carries the signature/docstring."""
+def _member_target(static) -> typing.Any:
+    """Unwrap a descriptor to the callable that carries the signature/docstring.
+
+    Returns ``Any`` deliberately: the result is an arbitrary unwrapped object fed
+    to ``inspect.getsourcelines``/``signature`` (whose failures the callers catch),
+    so this is the one justified type boundary in the renderer (cf. torx's typed
+    ``_find_repo_root``)."""
     if isinstance(static, property):
         return static.fget
     if isinstance(static, functools.cached_property):

--- a/docs_site/scripts/thrml_render/api_reference.py
+++ b/docs_site/scripts/thrml_render/api_reference.py
@@ -1,15 +1,36 @@
-"""API reference: introspect the live thrml package and render docstrings."""
+"""API reference: introspect the live thrml package and render docstrings.
 
+Each documented class renders its members (methods, properties, and attributes
+with their signatures and docstrings), reachable through the MRO and ordered by
+source line, so abstract bases and concrete classes alike show their interface
+rather than just a constructor signature. A symbol listed in a category but
+absent from its module is skipped with a warning, so a thrml API change never
+silently drops a symbol from the docs.
+"""
+
+from __future__ import annotations
+
+import functools
 import html as html_lib
 import importlib
 import inspect
+import math
 import re
+import sys
+import typing
+
+import equinox
 
 from .config import (
     _API_TOKEN_RE,
     _API_XREF_RE,
+    API_CATEGORIES,
     API_SYMBOL_URL,
 )
+
+# Distinguishes "the module has no such attribute" from "it exports it as None";
+# a bare ``getattr(..., None) is None`` conflates the two.
+_MISSING = object()
 
 
 def linkify_api(html, skip=None):
@@ -44,6 +65,27 @@ def linkify_types(text, self_name=None):
     return _API_TOKEN_RE.sub(repl, text)
 
 
+# Module-path noise stripped from rendered types; shared by the signature path
+# and the attribute-annotation path so the two can never diverge.
+_TYPE_NOISE_PATTERNS = (
+    r"jax\.jaxlib\._jax\.",
+    r"jaxtyping\.",
+    r"jaxlib\._jax\.",
+    r"collections\.abc\.",
+    r"equinox\._[\w.]+\.",
+    r"thrml\.[\w.]+\.",
+    # ``\b`` so the leading ``jax`` of ``jaxtyping.`` (stripped above) is never
+    # mis-matched, which would fuse e.g. ``jaxtyping.PyTree`` into ``jaxPyTree``.
+    r"\btyping\.",
+)
+
+
+def _strip_type_noise(s):
+    for pat in _TYPE_NOISE_PATTERNS:
+        s = re.sub(pat, "", s)
+    return s
+
+
 def _api_clean_sig(obj):
     # jitted functions (equinox.filter_jit, jax.jit) hide the real signature behind
     # a wrapper; unwrap to the underlying callable so the signature is meaningful.
@@ -53,16 +95,19 @@ def _api_clean_sig(obj):
     except (ValueError, TypeError):
         return "(...)"
     s = str(sig).replace("self, ", "").replace("self", "")
-    for pat in (
-        r"jax\.jaxlib\._jax\.",
-        r"jaxtyping\.",
-        r"jaxlib\._jax\.",
-        r"collections\.abc\.",
-        r"equinox\._[\w.]+\.",
-        r"thrml\.[\w.]+\.",
-    ):
-        s = re.sub(pat, "", s)
-    return re.sub(r" -> None$", "", s)
+    return re.sub(r" -> None$", "", _strip_type_noise(s))
+
+
+def _annotation_text(annotation):
+    """Render a field annotation to a compact string, preserving subscripts.
+
+    ``str(annotation)`` keeps subscripts (``dict[str, Array]``, ``tuple[int, ...]``)
+    that ``__name__`` would have dropped; the module-noise denylist then strips
+    the long dotted paths.
+    """
+    s = annotation if isinstance(annotation, str) else str(annotation)
+    s = re.sub(r"<class '([^']+)'>", r"\1", s)
+    return _strip_type_noise(s).strip()
 
 
 def _api_inline(s):
@@ -103,11 +148,11 @@ def _api_body(text):
 
 def render_docstring(doc):
     """Render a THRML docstring (light markdown + LaTeX) to themed HTML for MathJax."""
-    math = []
+    math_spans = []
 
     def stash(m):
-        math.append(m.group(0))
-        return f"\x00M{len(math) - 1}\x00"
+        math_spans.append(m.group(0))
+        return f"\x00M{len(math_spans) - 1}\x00"
 
     doc = re.sub(r"\$\$.*?\$\$", stash, doc, flags=re.S)
     doc = re.sub(r"\$[^$\n]+?\$", stash, doc)
@@ -139,7 +184,7 @@ def render_docstring(doc):
                 body.append(lines[i][4:] if lines[i].startswith("    ") else "")
                 i += 1
             inner = _api_body("\n".join(body))
-            for k, mx in enumerate(math):
+            for k, mx in enumerate(math_spans):
                 inner = inner.replace(f"\x00M{k}\x00", mx)
             out.append(f'<div class="api-note"><span class="api-note-t">{_api_inline(title)}</span>{inner}</div>')
             continue
@@ -171,27 +216,196 @@ def render_docstring(doc):
     flush()
     close_list()
     res = "\n".join(out)
-    for k, mx in enumerate(math):
+    for k, mx in enumerate(math_spans):
         res = res.replace(f"\x00M{k}\x00", mx)
     return res
+
+
+def _member_target(static: object) -> typing.Any:
+    """Unwrap a descriptor to the callable that carries the signature/docstring."""
+    if isinstance(static, property):
+        return static.fget
+    if isinstance(static, functools.cached_property):
+        return static.func
+    if isinstance(static, (staticmethod, classmethod)):
+        return static.__func__
+    return static
+
+
+# Sort key for members whose source line cannot be located (builtins, C-level);
+# they sort after every locatable member rather than at a magic line number.
+_UNLOCATABLE_LINENO = math.inf
+
+
+def _member_lineno(cls, name):
+    try:
+        static = inspect.getattr_static(cls, name)
+    except AttributeError:
+        static = getattr(cls, name, None)
+    target = _member_target(static)
+    try:
+        return inspect.getsourcelines(target)[1]
+    except (OSError, TypeError):
+        return _UNLOCATABLE_LINENO
+
+
+def _method_names(cls):
+    """Public methods and properties on cls, including inherited, source-ordered."""
+    names = []
+    for name in dir(cls):
+        if name.startswith("_"):
+            continue
+        try:
+            static = inspect.getattr_static(cls, name)
+        except AttributeError:
+            continue
+        is_member = (
+            isinstance(static, (property, functools.cached_property, staticmethod, classmethod))
+            or inspect.isfunction(static)
+            or inspect.ismethod(static)
+        )
+        if is_member:
+            names.append(name)
+    return sorted(names, key=lambda n: _member_lineno(cls, n))
+
+
+def _is_abstract_annotation(ftype):
+    """True if the annotation marks an abstract or class-level field that is not a
+    concrete instance attribute (``equinox.AbstractVar`` / ``typing.ClassVar``)."""
+    if ftype is equinox.AbstractVar or ftype is typing.ClassVar:
+        return True
+    if typing.get_origin(ftype) in (equinox.AbstractVar, typing.ClassVar):
+        return True
+    if isinstance(ftype, str) and re.match(r"(\w+\.)?(AbstractVar|ClassVar)\b", ftype):
+        return True
+    return False
+
+
+def _public_fields(cls):
+    """Public concrete annotated fields across the MRO (equinox/dataclass attrs).
+
+    Abstract interface annotations (``AbstractVar``) and class-level ``ClassVar``
+    annotations are skipped, as are names a subclass overrides with a
+    property/descriptor, so an abstract ``dims: AbstractVar`` never leaks in and
+    shadows the concrete ``dims`` property.
+    """
+    seen = set()
+    fields = []
+    for klass in inspect.getmro(cls):
+        if klass is object:
+            continue
+        for fname, ftype in getattr(klass, "__annotations__", {}).items():
+            if fname.startswith("_") or fname in seen:
+                continue
+            seen.add(fname)
+            if _is_abstract_annotation(ftype):
+                continue
+            try:
+                static = inspect.getattr_static(cls, fname)
+            except AttributeError:
+                static = None
+            if isinstance(static, (property, functools.cached_property)) or inspect.isdatadescriptor(static):
+                continue
+            fields.append((fname, ftype))
+    return fields
+
+
+def _render_field(cls_name, fname, ftype):
+    name = html_lib.escape(fname)
+    sig = linkify_types(html_lib.escape(f"{fname}: {_annotation_text(ftype)}"), self_name=cls_name)
+    return (
+        f'<div class="api-member" id="{cls_name}.{fname}">'
+        f'<div class="api-head"><code class="api-name">{name}</code>'
+        f'<span class="api-kind">attribute</span></div>'
+        f'<pre class="api-sig"><code>{sig}</code></pre>'
+        "</div>"
+    )
+
+
+def _render_member(cls, name, cls_name):
+    try:
+        static = inspect.getattr_static(cls, name)
+    except AttributeError:
+        static = getattr(cls, name, None)
+    target = _member_target(static)
+    if isinstance(static, (property, functools.cached_property)):
+        kind, sig = "property", ""
+    elif isinstance(static, staticmethod):
+        kind, sig = "staticmethod", _api_clean_sig(target)
+    elif isinstance(static, classmethod):
+        kind, sig = "classmethod", _api_clean_sig(target)
+    else:
+        kind, sig = "method", _api_clean_sig(target)
+    doc = inspect.getdoc(target) or ""
+    sig_html = linkify_types(html_lib.escape(name + sig), self_name=cls_name)
+    body = linkify_api(render_docstring(doc), skip={cls_name}) if doc else ""
+    return (
+        f'<div class="api-member" id="{cls_name}.{name}">'
+        f'<div class="api-head"><code class="api-name">{html_lib.escape(name)}</code>'
+        f'<span class="api-kind">{kind}</span></div>'
+        f'<pre class="api-sig"><code>{sig_html}</code></pre>'
+        f'<div class="api-doc">{body}</div>'
+        "</div>"
+    )
+
+
+def _render_members(cls, cls_name):
+    """Field and method member cards for a class, fields first, then methods in
+    source order. Names carried by both (a field shadowed by a property) render
+    once, as a field."""
+    fields = _public_fields(cls)
+    field_names = {fname for fname, _ in fields}
+    out = [_render_field(cls_name, fname, ftype) for fname, ftype in fields]
+    for member in _method_names(cls):
+        if member in field_names:
+            continue
+        out.append(_render_member(cls, member, cls_name))
+    return "".join(out)
+
+
+def validate_api_reference():
+    """Warn (without raising) about symbols listed in a category but absent from
+    their module, so a thrml API rename surfaces in the build log instead of
+    silently dropping the symbol from the docs."""
+    missing = []
+    for cat in API_CATEGORIES:
+        mod = importlib.import_module(cat["module"])
+        for name in cat["symbols"]:
+            if not hasattr(mod, name):
+                missing.append(f"{cat['module']}.{name}")
+    if missing:
+        print(
+            "warning: API_CATEGORIES lists symbols missing from their module "
+            f"(they will be skipped): {sorted(missing)}",
+            file=sys.stderr,
+        )
 
 
 def api_inner(cat):
     mod = importlib.import_module(cat["module"])
     parts = [f"<h1>{cat['label']}</h1>\n", f'<p class="lede">{linkify_types(cat["blurb"])}</p>\n']
     for name in cat["symbols"]:
-        obj = getattr(mod, name, None)
-        if obj is None:
+        obj = getattr(mod, name, _MISSING)
+        if obj is _MISSING:
+            print(
+                f"warning: API symbol {name!r} is not exported by {cat['module']}; skipping",
+                file=sys.stderr,
+            )
             continue
         target = getattr(obj, "__wrapped__", obj)
         sig = linkify_types(html_lib.escape(name + _api_clean_sig(obj)), self_name=name)
         doc = inspect.getdoc(target) or ""
         kind = "class" if inspect.isclass(target) else "function"
-        parts.append(
+        section = [
             f'<section class="api-sym" id="{name}">'
             f'<div class="api-head"><code class="api-name">{name}</code><span class="api-kind">{kind}</span></div>'
             f'<pre class="api-sig"><code>{sig}</code></pre>'
             f'<div class="api-doc">{linkify_api(render_docstring(doc), skip={name})}</div>'
-            "</section>"
-        )
+        ]
+        if inspect.isclass(target):
+            members = _render_members(target, name)
+            if members:
+                section.append(f'<div class="api-members">{members}</div>')
+        section.append("</section>")
+        parts.append("".join(section))
     return "".join(parts)

--- a/docs_site/scripts/thrml_render/api_reference.py
+++ b/docs_site/scripts/thrml_render/api_reference.py
@@ -250,10 +250,12 @@ def _member_lineno(cls, name):
 
 
 def _method_names(cls):
-    """Public methods and properties on cls, including inherited, source-ordered."""
+    """Public methods and properties on cls (plus ``__call__``), inherited, source-ordered."""
     names = []
     for name in dir(cls):
-        if name.startswith("_"):
+        # Skip private/dunder names except __call__, the contract method of the
+        # callable protocols (AbstractObserver, the conditional samplers).
+        if name.startswith("_") and name != "__call__":
             continue
         try:
             static = inspect.getattr_static(cls, name)

--- a/docs_site/scripts/thrml_render/assets.py
+++ b/docs_site/scripts/thrml_render/assets.py
@@ -24,7 +24,8 @@ def css(blob):
     Asserts the placeholder is fully resolved, so a malformed ASSET_BASE/ token
     fails loudly at build time instead of shipping a broken font url."""
     resolved = blob.replace("ASSET_BASE/", ASSET_BASE.rstrip("/") + "/")
-    assert "ASSET_BASE/" not in resolved, "unresolved ASSET_BASE/ placeholder after substitution"
+    if "ASSET_BASE/" in resolved:
+        raise RuntimeError("unresolved ASSET_BASE/ placeholder after substitution")
     return f"<style>\n{resolved}</style>\n"
 
 

--- a/docs_site/scripts/thrml_render/assets.py
+++ b/docs_site/scripts/thrml_render/assets.py
@@ -19,8 +19,13 @@ def _read(name):
 
 def css(blob):
     """Wrap raw CSS in a <style> block, resolving the ASSET_BASE/ placeholder in
-    @font-face urls to the configured CDN host."""
-    return f"<style>\n{blob.replace('ASSET_BASE/', ASSET_BASE.rstrip('/') + '/')}</style>\n"
+    @font-face urls to the configured CDN host.
+
+    Asserts the placeholder is fully resolved, so a malformed ASSET_BASE/ token
+    fails loudly at build time instead of shipping a broken font url."""
+    resolved = blob.replace("ASSET_BASE/", ASSET_BASE.rstrip("/") + "/")
+    assert "ASSET_BASE/" not in resolved, "unresolved ASSET_BASE/ placeholder after substitution"
+    return f"<style>\n{resolved}</style>\n"
 
 
 def js(blob):

--- a/docs_site/scripts/thrml_render/chrome.py
+++ b/docs_site/scripts/thrml_render/chrome.py
@@ -1,8 +1,13 @@
 """Shared page chrome (top bar, sidebar, nav) and notebook link rewriting."""
 
+from __future__ import annotations
+
 import html as html_lib
 import re
 from pathlib import Path
+
+# A sidebar/reading-order entry: (notebook number, title, href).
+Entry = tuple[str, str, str]
 
 from .assets import COLLAPSE_SCRIPT, COLLAPSE_STYLE, css, js
 from .config import (
@@ -13,6 +18,7 @@ from .config import (
     LOGO_SVG,
     SPECULATION_RULES,
 )
+from .text import replace_once
 
 
 def build_topbar():
@@ -72,22 +78,29 @@ def build_sidebar(entries, active_stem=None, active_page=None, active_api=None):
     return "".join(parts)
 
 
-def _add_body_class(html, cls):
+def _inject_body(html, body_class, chrome):
+    """Add a body class and inject the chrome markup in one pass over <body>.
+
+    Raises if there is not exactly one ``<body>`` so a notebook cell that emits a
+    stray ``<body`` (or a template change) fails loudly instead of injecting the
+    sidebar at the wrong spot."""
+    if html.count("<body") != 1:
+        raise RuntimeError(f"expected exactly one <body> marker, found {html.count('<body')}")
     match = re.search(r"<body([^>]*)>", html)
     if not match:
-        return html
+        raise RuntimeError("missing <body> marker")
     attrs = match.group(1)
     if 'class="' in attrs:
-        attrs = re.sub(r'class="', f'class="{cls} ', attrs, count=1)
+        attrs = re.sub(r'class="', f'class="{body_class} ', attrs, count=1)
     else:
-        attrs = attrs + f' class="{cls}"'
-    return html[: match.start()] + f"<body{attrs}>" + html[match.end() :]
+        attrs = attrs + f' class="{body_class}"'
+    return html[: match.start()] + f"<body{attrs}>{chrome}" + html[match.end() :]
 
 
-def reading_order(entries):
+def reading_order(entries: list[Entry]) -> list[Entry]:
     """Notebook entries flattened into the sidebar reading order."""
     by_num = {number: (title, href) for number, title, href in entries}
-    ordered = []
+    ordered: list[Entry] = []
     for _name, _sub, nums in INDEX_SECTIONS:
         for number in nums:
             if number in by_num:
@@ -121,23 +134,19 @@ def prev_next_nav(entries, active_stem):
 
 def inject_chrome(html, entries, active_stem):
     """Add the theme, top bar, and sidebar to an exported notebook page."""
-    if "</head>" in html:
-        html = html.replace("</head>", "\n" + css(COLLAPSE_STYLE) + "</head>", 1)
-    html = _add_body_class(html, "thrml-has-sidebar")
+    html = replace_once(html, "</head>", "\n" + css(COLLAPSE_STYLE) + "</head>", "</head> marker")
     chrome = build_topbar() + build_sidebar(entries, active_stem=active_stem)
-    html = re.sub(r"(<body[^>]*>)", lambda m: m.group(1) + chrome, html, count=1)
+    html = _inject_body(html, "thrml-has-sidebar", chrome)
     nav = prev_next_nav(entries, active_stem)
-    if nav and "</main>" in html:
-        html = html.replace("</main>", nav + "</main>", 1)
-    if "</body>" in html:
-        html = html.replace("</body>", "\n" + js(COLLAPSE_SCRIPT) + SPECULATION_RULES + "</body>", 1)
-    return html
+    if nav:
+        html = replace_once(html, "</main>", nav + "</main>", "</main> marker")
+    return replace_once(html, "</body>", "\n" + js(COLLAPSE_SCRIPT) + SPECULATION_RULES + "</body>", "</body> marker")
 
 
 def rewrite_nb_links(html: str) -> str:
     """Rewrite relative cross-notebook links from .ipynb to .html. Absolute URLs
     (which contain ``://``) are left untouched."""
-    return re.sub(r'href="([^":#]*?)\.ipynb(#[^"]*)??"', _nb_to_html, html)
+    return re.sub(r'href="([^":#]*?)\.ipynb(#[^"]*)?"', _nb_to_html, html)
 
 
 def rewrite_local_images(html: str) -> str:

--- a/docs_site/scripts/thrml_render/chrome.py
+++ b/docs_site/scripts/thrml_render/chrome.py
@@ -1,13 +1,8 @@
 """Shared page chrome (top bar, sidebar, nav) and notebook link rewriting."""
 
-from __future__ import annotations
-
 import html as html_lib
 import re
 from pathlib import Path
-
-# A sidebar/reading-order entry: (notebook number, title, href).
-Entry = tuple[str, str, str]
 
 from .assets import COLLAPSE_SCRIPT, COLLAPSE_STYLE, css, js
 from .config import (
@@ -51,7 +46,7 @@ def build_sidebar(entries, active_stem=None, active_page=None, active_api=None):
     parts.append(doc_link("concepts", "Concepts"))
     parts.append('<div class="sb-section">Examples</div>')
     for name, _sub, nums in INDEX_SECTIONS:
-        parts.append(f'<div class="sb-group"><div class="sb-grouphead">{name}</div>')
+        parts.append(f'<div class="sb-group"><div class="sb-grouphead">{html_lib.escape(name, quote=False)}</div>')
         for number in nums:
             if number not in by_num:
                 continue
@@ -59,7 +54,7 @@ def build_sidebar(entries, active_stem=None, active_page=None, active_api=None):
             stem = href[:-5]
             cls = "sb-nb active" if active_stem == stem else "sb-nb"
             parts.append(
-                f'<a class="{cls}" href="{href}"><span class="sb-n">{number}</span><span class="sb-t">{title}</span></a>'
+                f'<a class="{cls}" href="{html_lib.escape(href, quote=True)}"><span class="sb-n">{number}</span><span class="sb-t">{html_lib.escape(title, quote=False)}</span></a>'
             )
         parts.append("</div>")
     parts.append('<div class="sb-section">API reference</div>')
@@ -97,10 +92,10 @@ def _inject_body(html, body_class, chrome):
     return html[: match.start()] + f"<body{attrs}>{chrome}" + html[match.end() :]
 
 
-def reading_order(entries: list[Entry]) -> list[Entry]:
+def reading_order(entries):
     """Notebook entries flattened into the sidebar reading order."""
     by_num = {number: (title, href) for number, title, href in entries}
-    ordered: list[Entry] = []
+    ordered = []
     for _name, _sub, nums in INDEX_SECTIONS:
         for number in nums:
             if number in by_num:
@@ -116,7 +111,8 @@ def prev_next_nav(entries, active_stem):
     if idx is None:
         return ""
 
-    def card(number, title, href, direction):
+    def card(entry, direction):
+        number, title, href = entry
         arrow = "&larr; Previous" if direction == "prev" else "Next &rarr;"
         return (
             f'<a class="thrml-pn thrml-pn-{direction}" href="{href}">'
@@ -125,9 +121,9 @@ def prev_next_nav(entries, active_stem):
             f"{html_lib.escape(title)}</span></a>"
         )
 
-    prev_html = card(*ordered[idx - 1], "prev") if idx > 0 else '<span class="thrml-pn thrml-pn-empty"></span>'
+    prev_html = card(ordered[idx - 1], "prev") if idx > 0 else '<span class="thrml-pn thrml-pn-empty"></span>'
     next_html = (
-        card(*ordered[idx + 1], "next") if idx < len(ordered) - 1 else '<span class="thrml-pn thrml-pn-empty"></span>'
+        card(ordered[idx + 1], "next") if idx < len(ordered) - 1 else '<span class="thrml-pn thrml-pn-empty"></span>'
     )
     return '<nav class="thrml-pagenav" aria-label="Notebook navigation">' + prev_html + next_html + "</nav>"
 
@@ -143,24 +139,24 @@ def inject_chrome(html, entries, active_stem):
     return replace_once(html, "</body>", "\n" + js(COLLAPSE_SCRIPT) + SPECULATION_RULES + "</body>", "</body> marker")
 
 
-def rewrite_nb_links(html: str) -> str:
+def rewrite_nb_links(html):
     """Rewrite relative cross-notebook links from .ipynb to .html. Absolute URLs
     (which contain ``://``) are left untouched."""
     return re.sub(r'href="([^":#]*?)\.ipynb(#[^"]*)?"', _nb_to_html, html)
 
 
-def rewrite_local_images(html: str) -> str:
+def rewrite_local_images(html):
     """Point notebook <img> tags at file-backed figures (e.g. fps.png, saved by a
     notebook and committed beside it) to the externalized copy under assets/."""
     return re.sub(r'src="\.{0,2}/?([\w./-]+\.png)"', lambda m: f'src="assets/{Path(m.group(1)).name}"', html)
 
 
-def fix_known_links(html: str) -> str:
+def fix_known_links(html):
     for bad, good in _LINK_FIXES.items():
         html = html.replace(bad, good)
     return html
 
 
-def _nb_to_html(m: re.Match) -> str:
+def _nb_to_html(m):
     stem, anchor = m.group(1), m.group(2) or ""
     return f'href="{stem}.html{anchor}"'

--- a/docs_site/scripts/thrml_render/config.py
+++ b/docs_site/scripts/thrml_render/config.py
@@ -220,3 +220,41 @@ SKIP_RENDER = set()
 
 
 SITE_URL = "https://docs.thrml.ai"
+
+
+def notebook_numbers(paths=None):
+    """Published notebook numbers (NN prefixes), in filesystem discovery order."""
+    if paths is None:
+        paths = sorted(NB_DIR.glob("[0-9]*.ipynb"))
+    return [p.stem.split("_", 1)[0] for p in paths if p.stem not in SKIP_RENDER]
+
+
+def validate_notebook_catalog(paths=None):
+    """Cross-check the notebooks on disk against INDEX_SECTIONS and INDEX_BLURBS.
+
+    Returns a list of human-readable error strings (empty when consistent) so the
+    build can fail loudly on a duplicated number, a notebook missing from the
+    sidebar catalog, or a blurb with no notebook, instead of silently dropping it
+    from the nav and the examples gallery.
+    """
+    # A SKIP_RENDER notebook is present on disk but kept off the site, so exclude
+    # its number from the catalog side too; otherwise the (still-listed) skipped
+    # notebook looks like a mismatch and would false-fail the build.
+    skip_numbers = {stem.split("_", 1)[0] for stem in SKIP_RENDER}
+    numbers = notebook_numbers(paths)  # already excludes SKIP_RENDER stems
+    section_numbers = [num for _name, _blurb, nums in INDEX_SECTIONS for num in nums if num not in skip_numbers]
+    blurb_numbers = set(INDEX_BLURBS) - skip_numbers
+    errors = []
+    if len(set(numbers)) != len(numbers):
+        errors.append(f"duplicate notebook numbers: {numbers}")
+    if len(set(section_numbers)) != len(section_numbers):
+        errors.append(f"duplicate INDEX_SECTIONS numbers: {section_numbers}")
+    if set(numbers) != set(section_numbers):
+        errors.append("notebook/catalog mismatch: " f"notebooks={sorted(numbers)}, catalog={sorted(section_numbers)}")
+    missing_blurbs = sorted(set(numbers) - blurb_numbers)
+    extra_blurbs = sorted(blurb_numbers - set(numbers))
+    if missing_blurbs:
+        errors.append(f"missing INDEX_BLURBS entries: {missing_blurbs}")
+    if extra_blurbs:
+        errors.append(f"INDEX_BLURBS entries without notebooks: {extra_blurbs}")
+    return errors

--- a/docs_site/scripts/thrml_render/notebooks.py
+++ b/docs_site/scripts/thrml_render/notebooks.py
@@ -10,7 +10,10 @@ from .config import FIG_DIR
 
 
 def tag_hidden_inputs(nb):
-    """Mirror each cell's JupyterLab source_hidden state onto a hide-input tag."""
+    """Mirror each cell's JupyterLab source_hidden state onto a hide-input tag.
+
+    Mutates ``nb`` in place; the source ``.ipynb`` on disk is never touched.
+    """
     for cell in nb.cells:
         if cell.get("cell_type") != "code":
             continue
@@ -21,7 +24,6 @@ def tag_hidden_inputs(nb):
         if "hide-input" not in tags:
             tags.append("hide-input")
         cell.metadata["tags"] = tags
-    return nb
 
 
 def build_exporter():

--- a/docs_site/scripts/thrml_render/pages.py
+++ b/docs_site/scripts/thrml_render/pages.py
@@ -78,18 +78,18 @@ def examples_inner(entries):
         "its outputs.</p>",
     ]
     for name, blurb, nums in INDEX_SECTIONS:
-        parts.append(f"<h2>{name}</h2>")
+        parts.append(f"<h2>{html_lib.escape(name, quote=False)}</h2>")
         if blurb:
-            parts.append(f"<p>{blurb}</p>")
+            parts.append(f"<p>{html_lib.escape(blurb, quote=False)}</p>")
         parts.append('<div class="thrml-cards">')
         for number in nums:
             if number not in by_num:
                 continue
             title, href = by_num[number]
             parts.append(
-                f'<a class="thrml-card2" href="{href}">'
-                f'<span class="c2t">{number} &middot; {title}</span>'
-                f'<span class="c2b">{INDEX_BLURBS.get(number, "")}</span></a>'
+                f'<a class="thrml-card2" href="{html_lib.escape(href, quote=True)}">'
+                f'<span class="c2t">{number} &middot; {html_lib.escape(title, quote=False)}</span>'
+                f'<span class="c2b">{html_lib.escape(INDEX_BLURBS.get(number, ""), quote=False)}</span></a>'
             )
         parts.append("</div>")
     return "\n".join(parts)
@@ -283,10 +283,10 @@ def write_index(entries):
         title, href = by_num[num]
         blurb = INDEX_BLURBS.get(num, "")
         return (
-            f'      <a class="card" href="{href}">'
+            f'      <a class="card" href="{html_lib.escape(href, quote=True)}">'
             f'<span class="card-num">{num}</span>'
-            f'<span class="card-title">{title}</span>'
-            f'<span class="card-blurb">{blurb}</span></a>'
+            f'<span class="card-title">{html_lib.escape(title, quote=False)}</span>'
+            f'<span class="card-blurb">{html_lib.escape(blurb, quote=False)}</span></a>'
         )
 
     featured_cards = "\n".join(card(n) for n in ("00", "01", "02") if n in by_num)
@@ -436,6 +436,6 @@ def write_llms_txt(entries):
     out += ["", "## API reference"]
     for cat in API_CATEGORIES:
         mod = importlib.import_module(cat["module"])
-        present = ", ".join(s for s in cat["symbols"] if getattr(mod, s, None) is not None)
+        present = ", ".join(s for s in cat["symbols"] if hasattr(mod, s))
         out.append(f"- [{cat['label']}]({SITE_URL}/{cat['slug']}.html): {cat['blurb']} ({present})")
     (OUT_DIR / "llms.txt").write_text("\n".join(out) + "\n", encoding="utf-8")

--- a/docs_site/scripts/thrml_render/text.py
+++ b/docs_site/scripts/thrml_render/text.py
@@ -1,0 +1,17 @@
+"""Small text-substitution helpers shared across the renderer."""
+
+from __future__ import annotations
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    """Substitute the single expected occurrence of ``old`` with ``new``.
+
+    Raises if ``old`` does not appear exactly once, so a template change or a
+    notebook cell that emits a stray marker (e.g. raw HTML containing a literal
+    ``</main>``) fails loudly at build time instead of silently injecting chrome
+    at the wrong spot. ``label`` names the marker in the error.
+    """
+    count = text.count(old)
+    if count != 1:
+        raise RuntimeError(f"expected exactly one {label}, found {count}")
+    return text.replace(old, new, 1)

--- a/docs_site/scripts/thrml_render/text.py
+++ b/docs_site/scripts/thrml_render/text.py
@@ -1,9 +1,7 @@
 """Small text-substitution helpers shared across the renderer."""
 
-from __future__ import annotations
 
-
-def replace_once(text: str, old: str, new: str, label: str) -> str:
+def replace_once(text, old, new, label):
     """Substitute the single expected occurrence of ``old`` with ``new``.
 
     Raises if ``old`` does not appear exactly once, so a template change or a

--- a/docs_site/tests/test_docs_render.py
+++ b/docs_site/tests/test_docs_render.py
@@ -7,8 +7,6 @@ the top-level ``tests/``) and ``importorskip``s the docs extras, so it runs only
 in the docs-build job where ``nbconvert``/``nbformat`` are installed.
 """
 
-from __future__ import annotations
-
 import importlib
 import subprocess
 import sys

--- a/docs_site/tests/test_docs_render.py
+++ b/docs_site/tests/test_docs_render.py
@@ -1,0 +1,150 @@
+"""End-to-end checks for the docs site renderer (``docs_site/scripts``).
+
+Runs the real renderer once per session and asserts on the emitted HTML, so
+template drift, API-surface drift, or a regression in the per-class member
+rendering fails here instead of on deploy. Lives under ``docs_site/tests`` (not
+the top-level ``tests/``) and ``importorskip``s the docs extras, so it runs only
+in the docs-build job where ``nbconvert``/``nbformat`` are installed.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("nbconvert")
+pytest.importorskip("nbformat")
+
+pytestmark = pytest.mark.slow
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO / "docs_site" / "scripts"
+RENDERED = REPO / "docs_site" / "rendered"
+NOTEBOOKS = REPO / "examples"
+
+
+def _load(module_name):
+    """Import a renderer module out of ``docs_site/scripts`` at runtime."""
+    if str(SCRIPTS) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS))
+    return importlib.import_module(module_name)
+
+
+@pytest.fixture(scope="session")
+def site():
+    """Run the real site build once and return the rendered output dir."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPTS / "render_html.py")],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"render_html.py exited {result.returncode}\n" f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    return RENDERED
+
+
+def test_core_pages_exist_and_nonempty(site):
+    expected = ["index.html", "getting-started.html", "concepts.html", "examples.html", "llms.txt"]
+    expected += [p.name for p in sorted(site.glob("api-*.html"))]
+    expected += [f"{p.stem}.html" for p in sorted(NOTEBOOKS.glob("[0-9]*.ipynb"))]
+    assert len(list(site.glob("api-*.html"))) >= 1
+    assert len(list(NOTEBOOKS.glob("[0-9]*.ipynb"))) >= 1
+    for name in expected:
+        page = site / name
+        assert page.exists(), f"missing rendered page: {name}"
+        assert page.stat().st_size > 0, f"empty rendered page: {name}"
+
+
+def test_notebook_title_marker_replaced(site):
+    for page in site.glob("*.html"):
+        assert "<title>Notebook</title>" not in page.read_text(encoding="utf-8")
+
+
+def test_rewrite_nb_links_maps_relative_and_keeps_absolute():
+    chrome = _load("thrml_render.chrome")
+    rewrite = chrome.rewrite_nb_links
+    rel = rewrite('<a href="02_spin_models.ipynb">x</a>')
+    assert 'href="02_spin_models.html"' in rel
+    anchor = rewrite('<a href="01_all_of_thrml.ipynb#section">x</a>')
+    assert 'href="01_all_of_thrml.html#section"' in anchor
+    absolute = '<a href="https://example.com/nb/a.ipynb">x</a>'
+    assert rewrite(absolute) == absolute
+
+
+def test_linkify_api_wraps_code_spans():
+    api = _load("thrml_render.api_reference")
+    out = api.linkify_api("<p>Use <code>Block</code> first.</p>")
+    assert '<a class="api-xref"' in out
+    assert 'href="api-blocks.html#Block"' in out
+    assert "<code>Block</code>" in out
+
+
+def test_class_members_render(site):
+    # The renderer documents each class's members (methods/properties/attributes)
+    # with linkable per-member anchors, not just the constructor signature.
+    html = (site / "api-blocks.html").read_text(encoding="utf-8")
+    assert 'class="api-members"' in html
+    assert 'id="Block.nodes"' in html, "Block.nodes attribute member missing"
+    assert 'id="Block.node_type"' in html, "Block.node_type property member missing"
+
+
+def test_no_abstractvar_leaks_into_pages(site):
+    # _public_fields skips equinox AbstractVar / typing.ClassVar annotations, so an
+    # abstract interface field never renders as a concrete attribute.
+    for page in site.glob("api-*.html"):
+        assert "AbstractVar" not in page.read_text(encoding="utf-8"), f"AbstractVar leaked into {page.name}"
+
+
+def test_api_annotations_keep_generic_subscripts(site):
+    # Regression guard: attribute annotations must preserve generic subscripts
+    # (tuple[~_Node, ...]) rather than collapsing to a bare name.
+    text = "".join(page.read_text(encoding="utf-8") for page in site.glob("api-*.html"))
+    assert any(token in text for token in ("tuple[", "list[", "dict[")), "generic subscripts stripped"
+
+
+def test_no_asset_placeholder_remains(site):
+    for page in site.glob("*.html"):
+        assert "ASSET_BASE/" not in page.read_text(encoding="utf-8"), f"unresolved ASSET_BASE/ in {page.name}"
+
+
+def test_notebook_catalog_is_consistent():
+    config = _load("thrml_render.config")
+    assert config.validate_notebook_catalog() == []
+
+
+def test_replace_once_raises_on_missing_or_duplicate_marker():
+    text = _load("thrml_render.text")
+    with pytest.raises(RuntimeError):
+        text.replace_once("no marker here", "</main>", "x</main>", "</main> marker")
+    with pytest.raises(RuntimeError):
+        text.replace_once("<a></a><a></a>", "<a>", "<b>", "<a> marker")
+
+
+def test_annotation_text_strips_module_noise_without_mangling():
+    # Regression: a naive ``typing.`` strip used to fuse ``jaxtyping.PyTree`` into
+    # ``jaxPyTree``. The denylist must strip whole module prefixes only.
+    api = _load("thrml_render.api_reference")
+    assert api._annotation_text("dict[str, jaxtyping.PyTree]") == "dict[str, PyTree]"
+    assert api._annotation_text("typing.Optional[int]") == "Optional[int]"
+    assert "jaxPyTree" not in api._annotation_text("list[jaxtyping.PyTree]")
+
+
+def test_no_mangled_jax_prefix_in_pages(site):
+    for page in site.glob("api-*.html"):
+        assert "jaxPyTree" not in page.read_text(encoding="utf-8"), f"mangled jaxtyping prefix in {page.name}"
+
+
+def test_validate_catalog_tolerates_skip_render(monkeypatch):
+    # Skipping a notebook (present on disk, kept off the site) must not false-fail
+    # the catalog validator just because the notebook is still listed in the catalog.
+    config = _load("thrml_render.config")
+    stems = [p.stem for p in sorted(NOTEBOOKS.glob("[0-9]*.ipynb"))]
+    assert stems, "no example notebooks found"
+    monkeypatch.setattr(config, "SKIP_RENDER", {stems[-1]})
+    assert config.validate_notebook_catalog() == []

--- a/docs_site/tests/test_docs_render.py
+++ b/docs_site/tests/test_docs_render.py
@@ -140,6 +140,21 @@ def test_no_mangled_jax_prefix_in_pages(site):
         assert "jaxPyTree" not in page.read_text(encoding="utf-8"), f"mangled jaxtyping prefix in {page.name}"
 
 
+def test_member_docstring_latex_not_mangled(site):
+    # Raw-string LaTeX in member docstrings must survive: a non-raw "$\theta$" used to
+    # be parsed as "$<tab>heta$" and render as broken MathJax ("$ heta$").
+    html = (site / "api-samplers.html").read_text(encoding="utf-8")
+    assert "\\theta" in html, "\\theta missing/mangled in rendered member docs"
+    assert " heta$" not in html, "tab-mangled \\theta ($ heta$) shipped to the page"
+
+
+def test_callable_protocol_documents_dunder_call(site):
+    # __call__ is the contract method of callable protocols (AbstractObserver); member
+    # rendering must surface it rather than filtering it out as a dunder.
+    html = (site / "api-observers.html").read_text(encoding="utf-8")
+    assert 'id="AbstractObserver.__call__"' in html, "__call__ omitted from AbstractObserver members"
+
+
 def test_validate_catalog_tolerates_skip_render(monkeypatch):
     # Skipping a notebook (present on disk, kept off the site) must not false-fail
     # the catalog validator just because the notebook is still listed in the catalog.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,11 @@ line-length = 120
 
 [tool.pyright]
 reportUnnecessaryTypeIgnoreComment = true
-include = ["thrml"]
+include = ["thrml", "docs_site/scripts"]
+# The docs renderer lives under docs_site/scripts as the importable
+# ``thrml_render`` package; add it to the search path so its intra-package
+# imports resolve when pyright type-checks the renderer.
+extraPaths = ["docs_site/scripts"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/thrml/conditional_samplers.py
+++ b/thrml/conditional_samplers.py
@@ -172,7 +172,7 @@ class SoftmaxConditional(AbstractParametricConditionalSampler):
         sampler_state: None,
         output_sd: PyTree[jax.ShapeDtypeStruct],
     ) -> PyTree:
-        """A concrete implementation of this function has to return $\theta$ vector for every node
+        r"""A concrete implementation of this function has to return $\theta$ vector for every node
         in the block that is being updated. This array should have shape [b, M], where $M$ is the
         number of possible values that $X$ may take on."""
         pass
@@ -180,5 +180,5 @@ class SoftmaxConditional(AbstractParametricConditionalSampler):
     def sample_given_parameters(
         self, key: Key, parameters: PyTree, sampler_state: None, output_sd: PyTree[jax.ShapeDtypeStruct]
     ) -> tuple[_State, None]:
-        """Sample from a softmax distribution given the parameter vector $\theta$."""
+        r"""Sample from a softmax distribution given the parameter vector $\theta$."""
         return jax.random.categorical(key, parameters, axis=-1).astype(output_sd.dtype), sampler_state


### PR DESCRIPTION
## What
Brings the docs renderer (`docs_site`) up to the same quality bar as the `thrml` package, porting the hardening the torx renderer earned in review, and adds per-class API member rendering.

## Changes
- **API member rendering** — each documented class now lists its methods / properties / attributes with linkable anchors (introspected from the live package), not just the constructor signature.
- **HTML-injection safety** — `replace_once` + a raising `_inject_body`: a notebook cell emitting a stray `</main>`/`<body>` now fails the build loudly instead of silently misplacing the chrome.
- **Build validation** — `validate_notebook_catalog` (fail-loud, `SKIP_RENDER`-aware) + an API-drift warning, so a renamed symbol or unlisted notebook is caught.
- **Types + pyright** — `docs_site` is now type-checked under pyright (it was excluded); `extraPaths`/deps wired so the hook resolves the renderer package.
- **Tests + CI** — a build-invariant render test (`docs_site/tests/test_docs_render.py`) and a `docs-build` CI job.

## Invariant
Rendered output for the notebooks, `index.html`, and `llms.txt` is **byte-identical**; only the API pages (and the three docs pages that share `docs.css`) change.

## Review
Reviewed adversarially — two independent agents plus codex (bug-review + necessity-audit). Fixes included for `jaxtyping.PyTree`→`jaxPyTree` mangling, a `SKIP_RENDER` build-break, `__call__` omission on callable protocols, and tab-mangled `\theta` in two conditional-sampler docstrings.
