### PR TITLE
docs: self-host licensed fonts/videos (drop Vercel CDN)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 .vscode/
+
+# Private docs assets (licensed fonts/videos) cloned at build time
+docs_site/_assets/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,12 +5,12 @@ build:
   tools:
     python: "3.11"
   commands:
-    # Editable install so render_html.py can introspect the live thrml package
-    # for the API reference (also installs nbformat/nbconvert via the docs extra).
+    # Editable install so render_html.py can introspect the live thrml package.
     - pip install -e .[docs]
-    # Build the themed HTML (notebooks, prose pages, API reference, index,
-    # llms.txt) into docs_site/rendered/.
+    # Licensed fonts/videos from the private assets repo. DOCS_ASSETS_TOKEN is a
+    # read-only token set in the RTD project env; if it's missing the build still
+    # succeeds (pages fall back to system fonts).
+    - git clone --depth 1 "https://x-access-token:${DOCS_ASSETS_TOKEN}@github.com/extropic-ai/docs-assets.git" docs_site/_assets || echo "docs-assets unavailable; building without licensed fonts/videos"
     - python docs_site/scripts/render_html.py
-    # Publish the rendered site, including the brand fonts copied in at build time.
     - mkdir -p "$READTHEDOCS_OUTPUT/html"
     - cp -r docs_site/rendered/. "$READTHEDOCS_OUTPUT/html/"

--- a/docs_site/README.md
+++ b/docs_site/README.md
@@ -25,9 +25,9 @@ output and is gitignored.
 - The example notebooks are single-sourced from the repo's `examples/`
   directory (`NB_DIR = ROOT.parent / "examples"`), so adding a notebook there
   publishes it on the site.
-- The brand fonts and the hero/footer videos are licensed assets served from a
-  CDN rather than committed here. Repoint `ASSET_BASE` in `thrml_render/config.py`
-  at your host.
+- The brand fonts and hero/footer videos are licensed; the build pulls them from
+  the private `docs-assets` repo (cloned into `docs_site/_assets`) and serves
+  them from the docs host, so no external CDN is referenced.
 
 ## Adding a public API symbol
 

--- a/docs_site/scripts/render_html.py
+++ b/docs_site/scripts/render_html.py
@@ -35,6 +35,7 @@ from thrml_render.chrome import (
 from thrml_render.config import (
     API_CATEGORIES,
     BRAND_DIR,
+    DOCS_ASSETS_DIR,
     FIG_DIR,
     NB_DIR,
     OUT_DIR,
@@ -71,10 +72,7 @@ def copy_static():
     FIG_DIR.mkdir(parents=True, exist_ok=True)
     # The social-card image ships at the site root so og:image resolves to /og.png.
     shutil.copy2(BRAND_DIR / "og.png", OUT_DIR / "og.png")
-    # Figures committed beside notebooks or in the brand dir. The brand images
-    # (flow.png, extropic_wordmark.png) are licensed assets served from the CDN
-    # and intentionally absent from this public repo, so a missing source is
-    # skipped here (not a build error); the deploy mirror supplies them.
+    # Brand figures committed beside the notebooks (examples/) or in brand/.
     for src, dst in [
         (NB_DIR / "fps.png", FIG_DIR / "fps.png"),
         (NB_DIR / "codon_pipeline.png", FIG_DIR / "codon_pipeline.png"),
@@ -83,6 +81,7 @@ def copy_static():
     ]:
         if src.exists():
             shutil.copy2(src, dst)
+    copy_licensed_assets()
     # Committed static pages (e.g. the codon-optimization paper) copied verbatim,
     # so rendered/ holds them without a separate render step.
     if STATIC_DIR.is_dir():
@@ -91,6 +90,21 @@ def copy_static():
                 dst = OUT_DIR / src.relative_to(STATIC_DIR)
                 dst.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(src, dst)
+
+
+def copy_licensed_assets():
+    """Copy licensed fonts/videos from the docs-assets checkout into
+    rendered/. Absent checkout (local/CI) -> skip; pages fall back to system fonts."""
+    for sub in ("fonts", "videos"):
+        src_dir = DOCS_ASSETS_DIR / sub
+        if not src_dir.is_dir():
+            print(f"licensed assets: no {src_dir}; skipping {sub}/")
+            continue
+        dst_dir = OUT_DIR / sub
+        dst_dir.mkdir(parents=True, exist_ok=True)
+        for src in sorted(src_dir.iterdir()):
+            if src.is_file():
+                shutil.copy2(src, dst_dir / src.name)
 
 
 def main():

--- a/docs_site/scripts/thrml_render/assets.py
+++ b/docs_site/scripts/thrml_render/assets.py
@@ -19,10 +19,8 @@ def _read(name):
 
 def css(blob):
     """Wrap raw CSS in a <style> block, resolving the ASSET_BASE/ placeholder in
-    @font-face urls to the configured CDN host.
-
-    Asserts the placeholder is fully resolved, so a malformed ASSET_BASE/ token
-    fails loudly at build time instead of shipping a broken font url."""
+    @font-face urls to the page-relative assets path. Raises if it survives, so a
+    broken asset path fails the build instead of shipping."""
     resolved = blob.replace("ASSET_BASE/", ASSET_BASE.rstrip("/") + "/")
     if "ASSET_BASE/" in resolved:
         raise RuntimeError("unresolved ASSET_BASE/ placeholder after substitution")

--- a/docs_site/scripts/thrml_render/config.py
+++ b/docs_site/scripts/thrml_render/config.py
@@ -1,6 +1,7 @@
 """Paths, URLs, and pure-data configuration for the THRML docs build."""
 
 import html as html_lib
+import os
 import re
 from pathlib import Path
 
@@ -14,9 +15,14 @@ STATIC_DIR = ROOT / "static"
 
 INDEX_GITHUB = "https://github.com/extropic-ai/thrml"
 
-# Brand fonts and the hero/footer videos are licensed assets served from a CDN,
-# not committed to this public repo. Repoint ASSET_BASE at your preferred host.
-ASSET_BASE = "https://thrml-docs.vercel.app"
+# Licensed fonts/videos aren't committed (commercial license); the build copies
+# them from the private docs-assets checkout into rendered/ and serves them
+# page-relative (./fonts, ./videos) from the docs host -- no CDN. All pages live
+# at the output root, so a relative ref resolves on prod and RTD preview alike.
+ASSET_BASE = "."
+
+# docs-assets checkout; Read the Docs clones it here at build time.
+DOCS_ASSETS_DIR = Path(os.environ.get("THRML_DOCS_ASSETS") or (ROOT / "_assets"))
 
 
 # The THRML mark (Extropic brand). The source is monochrome; recoloring its fill

--- a/docs_site/static/papers/codon-optimization/index.html
+++ b/docs_site/static/papers/codon-optimization/index.html
@@ -10,14 +10,14 @@
   /* ---- Extropic brand, warm dark theme (overrides the lab template) ----
      Self-hosted brand fonts: Kessler Display (display serif, italic) for headings,
      Suisse BP Int'l for body, Suisse Int'l Mono for code/UI, Rephlex for the wordmark. */
-  @font-face { font-family: "Kessler Display W"; src: url(https://thrml-docs.vercel.app/fonts/kessler-display-italic.woff2) format("woff2"); font-weight: 400; font-style: italic; font-display: swap; }
-  @font-face { font-family: "Rephlex Trial"; src: url(https://thrml-docs.vercel.app/fonts/rephlex-regular.woff2) format("woff2"); font-weight: 400; font-style: normal; font-display: swap; }
-  @font-face { font-family: "Chakra Petch"; src: url(https://thrml-docs.vercel.app/fonts/chakra-petch-bold.woff2) format("woff2"); font-weight: 700; font-style: normal; font-display: swap; }
-  @font-face { font-family: "Suisse BP Int'l"; src: url(https://thrml-docs.vercel.app/fonts/suisse-intl-regular.woff2) format("woff2"); font-weight: 400; font-style: normal; font-display: swap; }
-  @font-face { font-family: "Suisse BP Int'l"; src: url(https://thrml-docs.vercel.app/fonts/suisse-intl-medium.woff2) format("woff2"); font-weight: 500; font-style: normal; font-display: swap; }
-  @font-face { font-family: "Suisse BP Int'l"; src: url(https://thrml-docs.vercel.app/fonts/suisse-intl-bold.woff2) format("woff2"); font-weight: 700; font-style: normal; font-display: swap; }
-  @font-face { font-family: "Suisse Int'l Mono"; src: url(https://thrml-docs.vercel.app/fonts/suisse-mono-regular.woff2) format("woff2"); font-weight: 400; font-style: normal; font-display: swap; }
-  @font-face { font-family: "Suisse Int'l Mono"; src: url(https://thrml-docs.vercel.app/fonts/suisse-mono-bold.woff2) format("woff2"); font-weight: 700; font-style: normal; font-display: swap; }
+  @font-face { font-family: "Kessler Display W"; src: url(../../fonts/kessler-display-italic.woff2) format("woff2"); font-weight: 400; font-style: italic; font-display: swap; }
+  @font-face { font-family: "Rephlex Trial"; src: url(../../fonts/rephlex-regular.woff2) format("woff2"); font-weight: 400; font-style: normal; font-display: swap; }
+  @font-face { font-family: "Chakra Petch"; src: url(../../fonts/chakra-petch-bold.woff2) format("woff2"); font-weight: 700; font-style: normal; font-display: swap; }
+  @font-face { font-family: "Suisse BP Int'l"; src: url(../../fonts/suisse-intl-regular.woff2) format("woff2"); font-weight: 400; font-style: normal; font-display: swap; }
+  @font-face { font-family: "Suisse BP Int'l"; src: url(../../fonts/suisse-intl-medium.woff2) format("woff2"); font-weight: 500; font-style: normal; font-display: swap; }
+  @font-face { font-family: "Suisse BP Int'l"; src: url(../../fonts/suisse-intl-bold.woff2) format("woff2"); font-weight: 700; font-style: normal; font-display: swap; }
+  @font-face { font-family: "Suisse Int'l Mono"; src: url(../../fonts/suisse-mono-regular.woff2) format("woff2"); font-weight: 400; font-style: normal; font-display: swap; }
+  @font-face { font-family: "Suisse Int'l Mono"; src: url(../../fonts/suisse-mono-bold.woff2) format("woff2"); font-weight: 700; font-style: normal; font-display: swap; }
   :root {
     --ex-orange: #FF8400; --ex-gold: #F5D64C; --ex-accent: #FF8400; --ex-copper: #903001; --ex-amber: #F0B86E; --ex-tan: #DCAE72;
     --ex-page: #0B0B0C; --ex-code-bg: #131211; --ex-code-border: #2C2926; --ex-frame: rgba(243,236,224,.11);

--- a/docs_site/tests/test_docs_render.py
+++ b/docs_site/tests/test_docs_render.py
@@ -200,3 +200,39 @@ def test_validate_catalog_tolerates_skip_render(monkeypatch):
     assert stems, "no example notebooks found"
     monkeypatch.setattr(config, "SKIP_RENDER", {stems[-1]})
     assert config.validate_notebook_catalog() == []
+
+
+def test_no_external_asset_cdn(site):
+    # Fonts/videos are served from the docs host; no Vercel/CDN refs leak through.
+    for page in site.rglob("*.html"):
+        text = page.read_text(encoding="utf-8")
+        rel = page.relative_to(site)
+        assert "vercel.app" not in text, f"vercel asset ref in {rel}"
+        assert "ASSET_BASE/" not in text, f"unresolved ASSET_BASE placeholder in {rel}"
+
+
+def test_fonts_referenced_relative(site):
+    # Generated pages reach the fonts page-relative; the static paper is two deep.
+    assert any("./fonts/" in p.read_text(encoding="utf-8") for p in site.glob("*.html"))
+    paper = (site / "papers" / "codon-optimization" / "index.html").read_text(encoding="utf-8")
+    assert "../../fonts/" in paper
+
+
+def test_copy_licensed_assets_from_checkout(tmp_path, monkeypatch):
+    # fonts/videos are copied from the docs-assets checkout; a missing
+    # checkout is skipped, not fatal.
+    render = _load("render_html")
+    checkout = tmp_path / "assets"
+    (checkout / "fonts").mkdir(parents=True)
+    (checkout / "videos").mkdir(parents=True)
+    (checkout / "fonts" / "suisse-intl-regular.woff2").write_bytes(b"f")
+    (checkout / "videos" / "extropic.mp4").write_bytes(b"v")
+    out = tmp_path / "rendered"
+    out.mkdir()
+    monkeypatch.setattr(render, "DOCS_ASSETS_DIR", checkout)
+    monkeypatch.setattr(render, "OUT_DIR", out)
+    render.copy_licensed_assets()
+    assert (out / "fonts" / "suisse-intl-regular.woff2").exists()
+    assert (out / "videos" / "extropic.mp4").exists()
+    monkeypatch.setattr(render, "DOCS_ASSETS_DIR", tmp_path / "absent")
+    render.copy_licensed_assets()


### PR DESCRIPTION
Serves the licensed brand fonts + hero/footer videos from the docs host instead of `thrml-docs.vercel.app`, so no `*.vercel.app` URL is referenced anywhere in the docs.

### How
- `ASSET_BASE` is now `"."` — fonts/videos are referenced page-relative (`./fonts/…`, `./videos/…`). Every rendered page sits at the output root, so the relative ref resolves identically on prod (`docs.thrml.ai`) and on RTD preview/version builds (no CORS, no version-prefix breakage).
- The build clones the private `thrml-docs-assets` repo into `docs_site/_assets`; `render_html.copy_licensed_assets()` copies `fonts/` + `videos/` into `rendered/`.
- The standalone codon paper (static, two levels deep) now uses `../../fonts/…`.
- A missing checkout (local dev / CI without the token) is skipped — the build still succeeds, pages fall back to system fonts.

### Verification
- Real build against the private assets: **0 `vercel.app` refs**, no unresolved `ASSET_BASE/` placeholder, all 8 fonts + 4 videos copied, pages reference `./fonts` / `./videos`.
- `docs_site/tests/test_docs_render.py`: 20 passed (3 new — no-CDN guard, relative refs, copy-from-checkout). isort/black/flake8/pyright clean.

### ⚠️ One-time RTD step (required for fonts to appear)
Add a read-only token for `extropic-ai/thrml-docs-assets` as the env var **`DOCS_ASSETS_TOKEN`** in the Read the Docs project settings. Until then the build is green but renders with system fonts.

### Note
`rephlex-regular.woff2` is a **trial** font ("internal testing only, not for distribution") and still backs the wordmark. Self-hosting doesn't change its license status — it needs a purchased copy or a swap. Pre-existing; out of scope here.