### PR TITLE
docs: syntax-highlight the getting-started code cards

### DIFF
--- a/docs_site/scripts/assets/docs.css
+++ b/docs_site/scripts/assets/docs.css
@@ -38,7 +38,24 @@
 .thrml-codecard pre { margin: 0; background: transparent; border: 0; padding: .35rem 1.05rem 1rem; overflow-x: auto;
   color: var(--ex-ink); font-family: var(--jp-code-font-family); font-size: 13px; line-height: 1.7; }
 .thrml-codecard pre code { background: none; color: inherit; padding: 0; font-size: inherit; }
-.thrml-codecard pre .cmt { color: #A8845A; font-style: italic; }
+.thrml-codecard pre code .c, .thrml-codecard pre code .c1, .thrml-codecard pre code .ch,
+.thrml-codecard pre code .cm, .thrml-codecard pre code .cp, .thrml-codecard pre code .cpf,
+.thrml-codecard pre code .cs { color: #A8845A; font-style: italic; }
+.thrml-codecard pre code .k, .thrml-codecard pre code .kc, .thrml-codecard pre code .kd,
+.thrml-codecard pre code .kn, .thrml-codecard pre code .kp, .thrml-codecard pre code .kr,
+.thrml-codecard pre code .kt, .thrml-codecard pre code .ow { color: var(--ex-gold); font-weight: 600; }
+.thrml-codecard pre code .s, .thrml-codecard pre code .sa, .thrml-codecard pre code .sb,
+.thrml-codecard pre code .sc, .thrml-codecard pre code .dl, .thrml-codecard pre code .sd,
+.thrml-codecard pre code .s2, .thrml-codecard pre code .se, .thrml-codecard pre code .sh,
+.thrml-codecard pre code .si, .thrml-codecard pre code .sx, .thrml-codecard pre code .sr,
+.thrml-codecard pre code .s1, .thrml-codecard pre code .ss { color: var(--ex-amber); }
+.thrml-codecard pre code .m, .thrml-codecard pre code .mb, .thrml-codecard pre code .mf,
+.thrml-codecard pre code .mh, .thrml-codecard pre code .mi, .thrml-codecard pre code .mo,
+.thrml-codecard pre code .il { color: var(--ex-orange); font-weight: 600; }
+.thrml-codecard pre code .nb, .thrml-codecard pre code .nn, .thrml-codecard pre code .bp { color: var(--ex-tan); }
+.thrml-codecard pre code .nc, .thrml-codecard pre code .nf, .thrml-codecard pre code .fm { color: var(--ex-math); }
+.thrml-codecard pre code .o, .thrml-codecard pre code .p, .thrml-codecard pre code .pm { color: var(--ex-muted); }
+.thrml-codecard pre code .w { color: inherit; }
 /* next-step cards */
 .thrml-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin: 1.4rem 0 .4rem; }
 .thrml-card2 { display: block; border: 1px solid var(--ex-copper); border-radius: 2px; padding: 1rem 1.15rem;

--- a/docs_site/scripts/assets/index.css
+++ b/docs_site/scripts/assets/index.css
@@ -139,7 +139,18 @@ a { color: var(--gold); text-decoration: none; }
 .codecard .copy.done { color: var(--gold); }
 .codecard pre { margin: 0; padding: .35rem 1.1rem 1rem; overflow-x: auto; color: var(--body);
   font-family: var(--mono); font-size: 12.5px; line-height: 1.78; }
-.codecard pre .cmt { color: #9a7a52; font-style: italic; }
+.codecard pre .c, .codecard pre .c1, .codecard pre .ch, .codecard pre .cm,
+.codecard pre .cp, .codecard pre .cpf, .codecard pre .cs { color: #9a7a52; font-style: italic; }
+.codecard pre .k, .codecard pre .kc, .codecard pre .kd, .codecard pre .kn,
+.codecard pre .kp, .codecard pre .kr, .codecard pre .kt, .codecard pre .ow { color: var(--gold); font-weight: 600; }
+.codecard pre .s, .codecard pre .sa, .codecard pre .sb, .codecard pre .sc, .codecard pre .dl,
+.codecard pre .sd, .codecard pre .s2, .codecard pre .se, .codecard pre .sh, .codecard pre .si,
+.codecard pre .sx, .codecard pre .sr, .codecard pre .s1, .codecard pre .ss { color: var(--solar); }
+.codecard pre .m, .codecard pre .mb, .codecard pre .mf, .codecard pre .mh,
+.codecard pre .mi, .codecard pre .mo, .codecard pre .il { color: var(--orange); font-weight: 600; }
+.codecard pre .nb, .codecard pre .nn, .codecard pre .bp,
+.codecard pre .o, .codecard pre .p, .codecard pre .pm { color: var(--muted); }
+.codecard pre .w { color: inherit; }
 .codecard pre .out { color: var(--muted); }
 
 /* examples: flat hairline cards */

--- a/docs_site/scripts/thrml_render/pages.py
+++ b/docs_site/scripts/thrml_render/pages.py
@@ -4,8 +4,8 @@ import html as html_lib
 import importlib
 
 from pygments import highlight
-from pygments.lexers import get_lexer_by_name
 from pygments.formatters import HtmlFormatter
+from pygments.lexers import get_lexer_by_name
 
 from .api_reference import linkify_api
 from .assets import (

--- a/docs_site/scripts/thrml_render/pages.py
+++ b/docs_site/scripts/thrml_render/pages.py
@@ -3,6 +3,10 @@
 import html as html_lib
 import importlib
 
+from pygments import highlight
+from pygments.lexers import get_lexer_by_name
+from pygments.formatters import HtmlFormatter
+
 from .api_reference import linkify_api
 from .assets import (
     COLLAPSE_SCRIPT,
@@ -33,12 +37,13 @@ from .config import (
 
 def code_card(code, lang="python"):
     """A self-contained docs code card matching the notebook code-cell look."""
-    esc = html_lib.escape(code.strip("\n"))
+    lexer = get_lexer_by_name(lang)
+    body = highlight(code.strip("\n"), lexer, HtmlFormatter(nowrap=True)).rstrip("\n")
     return (
         '<div class="thrml-codecard">'
         '<div class="thrml-code-head"><span class="thrml-lang">' + lang + "</span>"
         '<span class="thrml-tools"><button class="thrml-copy" type="button" title="Copy code" aria-label="Copy code"></button></span></div>'
-        "<pre><code>" + esc + "</code></pre>"
+        "<pre><code>" + body + "</code></pre>"
         "</div>"
     )
 

--- a/docs_site/scripts/thrml_render/pages.py
+++ b/docs_site/scripts/thrml_render/pages.py
@@ -301,23 +301,30 @@ def write_index(entries):
     n_examples = len(entries)
 
     copy_btn = '<button class="copy" type="button" aria-label="Copy code">' + COPY_SVG + "</button>"
-    first_model_card = (
-        '<div class="codecard"><div class="chead"><span>python</span>' + copy_btn + "</div>"
-        "<pre>import jax, jax.numpy as jnp\n"
+    quick_code = (
+        "import jax, jax.numpy as jnp\n"
         "from thrml import SpinNode, Block, SamplingSchedule, sample_states\n"
-        "from thrml.models import IsingEBM, IsingSamplingProgram, hinton_init\n\n"
-        '<span class="cmt"># A 5-spin Ising chain, two-coloured into parallel blocks</span>\n'
+        "from thrml.models import IsingEBM, IsingSamplingProgram, hinton_init\n"
+        "\n"
+        "# A 5-spin Ising chain, two-coloured into parallel blocks\n"
         "nodes = [SpinNode() for _ in range(5)]\n"
         "edges = [(nodes[i], nodes[i + 1]) for i in range(4)]\n"
         "model = IsingEBM(\n"
-        "    nodes, edges, jnp.zeros((5,)), jnp.ones((4,)) * 0.5, jnp.array(1.0))\n\n"
+        "    nodes, edges, jnp.zeros((5,)), jnp.ones((4,)) * 0.5, jnp.array(1.0))\n"
+        "\n"
         "free_blocks = [Block(nodes[::2]), Block(nodes[1::2])]\n"
-        "program = IsingSamplingProgram(model, free_blocks, clamped_blocks=[])\n\n"
+        "program = IsingSamplingProgram(model, free_blocks, clamped_blocks=[])\n"
+        "\n"
         "k_init, k_samp = jax.random.split(jax.random.key(0), 2)\n"
         "state = hinton_init(k_init, model, free_blocks, ())\n"
         "schedule = SamplingSchedule(n_warmup=100, n_samples=1000, steps_per_sample=2)\n"
         "samples = sample_states(\n"
-        "    k_samp, program, schedule, state, [], [Block(nodes)])\n"
+        "    k_samp, program, schedule, state, [], [Block(nodes)])"
+    )
+    quick_highlighted = highlight(quick_code, get_lexer_by_name("python"), HtmlFormatter(nowrap=True)).rstrip("\n")
+    first_model_card = (
+        '<div class="codecard"><div class="chead"><span>python</span>' + copy_btn + "</div>"
+        "<pre>" + quick_highlighted + "\n"
         '<span class="out"># samples: 1000 draws from the chain, by block Gibbs</span></pre></div>'
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ development = [
 ]
 docs = [
   "nbformat>=5.9",
-  "nbconvert>=7.0"
+  "nbconvert>=7.0",
+  "pygments>=2.13"
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- `code_card()` was HTML-escaping raw source and dropping it straight into `<pre><code>`, so the hand-authored getting-started page rendered as flat unhighlighted text
- every notebook-derived page already gets full Pygments highlighting for free via nbconvert's lab template, so this was just an inconsistency on the one hand-authored page
- run the same snippets through Pygments in `code_card()` and add matching token-color CSS rules built from the site's existing `--ex-*` brand tokens, replacing the one `.cmt` rule that was defined but never actually applied

## Test plan
- [x] regenerated the site with `docs_site/scripts/render_html.py` and confirmed `getting-started.html`'s 4 code cards now carry Pygments token spans
- [x] screenshotted the rendered python and bash cards in headless Chromium to check colors/contrast/spacing against the dark card background
- [x] confirmed the `--ex-gold`/`--ex-tan`/`--ex-math`/etc tokens referenced in the new CSS resolve (defined in `notebook.css`'s `:root`, loaded on every doc page via `COLLAPSE_STYLE`)