### PR TITLE
docs: mobile polish (hide RTD flyout, decramp phone topbar, responsive images)

### DIFF
--- a/docs_site/scripts/assets/index.css
+++ b/docs_site/scripts/assets/index.css
@@ -205,3 +205,5 @@ a { color: var(--gold); text-decoration: none; }
 @media (max-width: 360px) {
   .hero h1 { font-size: 22px; }
 }
+/* Read the Docs injects a version flyout; the site is single-version, so hide it. */
+readthedocs-flyout { display: none; }

--- a/docs_site/scripts/assets/notebook.css
+++ b/docs_site/scripts/assets/notebook.css
@@ -174,6 +174,8 @@ body.jp-Notebook > main > .jp-MarkdownCell:first-child .jp-RenderedHTMLCommon > 
   max-width: 100%; width: auto; height: auto;
   background: #ffffff; border-radius: 10px; padding: 12px;
   box-shadow: 0 0 0 1px rgba(243,236,224,.10); }
+/* Any other content image (markdown cells, doc pages) fits the column on phones. */
+.jp-RenderedHTMLCommon img, .thrml-doc img { max-width: 100%; height: auto; }
 /* The roadmap "From codons to Ising spins" figure is the original orange/blue
    designer figure (the two-category palette is semantically load-bearing) on white,
    so present it as a clean white card. box-sizing:border-box keeps the padding inside
@@ -306,8 +308,12 @@ mjx-container[display="true"] svg, mjx-container[display="true"] svg * { fill: v
   .thrml-topbar .thrml-title { font-size: 14px; letter-spacing: .08em; }
   .thrml-topbar .thrml-pills { gap: 5px; }
   .thrml-topbar .thrml-pill { font-size: 9px; padding: 5px 8px; letter-spacing: 0; }
+  /* The first two pills (Get started, Examples) duplicate the burger sidebar; drop them. */
+  .thrml-topbar .thrml-pill:nth-child(-n+2) { display: none; }
 }
 @media (max-width: 380px) { .thrml-topbar .thrml-title { display: none; } }
+/* Read the Docs injects a version flyout; the site is single-version, so hide it. */
+readthedocs-flyout { display: none; }
 
 /* ---- Left sidebar (docs + notebooks) ---- */
 .thrml-sidebar { position: fixed; top: 46px; left: 0; bottom: 0; width: 16.5rem; z-index: 997;


### PR DESCRIPTION
CSS-only, +8 LOC. Three small mobile fixes for the docs site:

- **Decramp the phone topbar.** At <=560px the bar squeezed burger + logo + THRML + four pills into one row. The first two pills (Get started, Examples) duplicate the burger sidebar, so they're hidden on phones; PAPER and GITHUB (which have no sidebar entry) stay. All four return at desktop widths.
- **Hide the Read the Docs version flyout.** RTD addons inject a floating `latest` version widget that overlaps the prev/next nav, and the site is single-version. Hidden via `readthedocs-flyout { display: none; }` in the shared theme and the landing CSS.
- **Images always fit the column.** Output figures and the codon-pipeline figure already had `max-width: 100%`; added the generic `.jp-RenderedHTMLCommon img, .thrml-doc img { max-width: 100%; height: auto; }` so any other markdown/doc image scales down too.

Verified locally: rebuilt the site, `docs_site/tests` pass (20/20), and swept every page at 390px — zero horizontal overflow, no image wider than the viewport, stubbed `<readthedocs-flyout>` computes `display: none`, and the topbar reads `logo / THRML / PAPER / GITHUB`.