### PR TITLE
docs: clarify numpy 2 compatibility in install section (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ or
 uv pip install thrml
 ```
 
+### NumPy compatibility
+
+THRML is compatible with NumPy 2.x when paired with a modern JAX release (JAX ≥ 0.5; the current release line works out of the box). Older JAX releases (< 0.5) had known incompatibilities with NumPy 2 — if you are pinned to an older JAX and see NumPy-related import or runtime errors, constrain NumPy in your own environment:
+
+```bash
+pip install "numpy<2"
+```
+
+See [issue #19](https://github.com/extropic-ai/thrml/issues/19) for context.
+
 ## Documentation
 
 Available at [docs.thrml.ai](https://docs.thrml.ai/en/latest/).


### PR DESCRIPTION
Refs #19.

## What this is
A documentation fix, not a code change. The original issue reported that running the example notebooks produced numpy-2-related import errors and asked for a `requirements.txt` with `numpy==1.26.4`.

## Why docs instead of a pin
The original breakage was a JAX-side incompatibility that upstream resolved in JAX 0.5+. Verified on current main (`9c4e6fbb`):

```
Python 3.12.13 (fresh uv venv)
jax 0.11.1 / jaxlib 0.11.1
numpy 2.5.2  ← latest
thrml 0.1.4 (editable install)

pytest tests/ -m "not slow"
→ 59 passed, 0 failed, 28s
```

Pinning `numpy<2` in `pyproject.toml` today would force users onto the EOL NumPy 1.x branch and contradict upstream JAX support. The existing loose requirement (`lockwo`'s call in the issue thread) is correct.

## What the PR does
Adds a "NumPy compatibility" subsection under Installation explaining:
1. Modern JAX (≥0.5) + NumPy 2 works out of the box.
2. Users pinned to legacy JAX can apply `pip install "numpy<2"` in their own environment.
3. Links back to #19 for context.

Suggest closing #19 on merge.