### PR TITLE
validate NumPy leaves in InteractionGroup's shape check

### DIFF
--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -1,6 +1,7 @@
 import unittest
 
 import jax.numpy as jnp
+import numpy as np
 
 from thrml.block_management import Block
 from thrml.interaction import InteractionGroup
@@ -41,3 +42,24 @@ class TestInteractionInputs(unittest.TestCase):
         with self.assertRaises(RuntimeError) as error:
             _ = InteractionGroup(bad_interaction, self.good_head, self.good_tails)
         self.assertIn("leading dimension", str(error.exception))
+
+    def test_good_numpy_interaction(self):
+        _ = InteractionGroup(np.zeros((len(self.good_head),)), self.good_head, self.good_tails)
+
+    def test_bad_numpy_interaction(self):
+        # NumPy leaves are arrays as far as the sampler is concerned: it gathers them along axis 0
+        # with `jnp.take`, which fills out-of-range reads instead of failing. So they have to be
+        # validated exactly like JAX arrays are.
+        for bad_leaf in (
+            np.zeros((len(self.good_head) - 1,)),
+            np.zeros((len(self.good_head) + 1,)),
+            np.array(1.0),
+            np.float32(1.0),
+        ):
+            with self.subTest(leaf=bad_leaf):
+                with self.assertRaises(RuntimeError) as error:
+                    _ = InteractionGroup((self.good_interaction, bad_leaf), self.good_head, self.good_tails)
+                self.assertIn("leading dimension", str(error.exception))
+
+    def test_non_array_leaves_are_skipped(self):
+        _ = InteractionGroup((self.good_interaction, 1.0, 7, None), self.good_head, self.good_tails)

--- a/thrml/interaction.py
+++ b/thrml/interaction.py
@@ -1,6 +1,5 @@
 import equinox as eqx
 import jax
-import jax.numpy as jnp
 from jaxtyping import PyTree
 
 from thrml.block_management import Block
@@ -52,8 +51,10 @@ class InteractionGroup(eqx.Module):
             if not len(block.nodes) == interaction_size:
                 raise RuntimeError("All tail node blocks must have the same length as head_nodes")
 
+        # `eqx.is_array` is the predicate `_tree_slice` uses to decide which leaves get gathered
+        # along axis 0 during sampling, so validation has to use it too or the two disagree.
         def _get_dim(x):
-            return (-1 if not len(x.shape) else x.shape[0]) if isinstance(x, jnp.ndarray) else interaction_size
+            return (-1 if not len(x.shape) else x.shape[0]) if eqx.is_array(x) else interaction_size
 
         dims = jax.tree.leaves(jax.tree.map(_get_dim, interaction))
         if not all(dim == interaction_size for dim in dims):


### PR DESCRIPTION
`InteractionGroup.__init__` checks that every array in `interaction` has a leading dimension equal to `len(head_nodes)`, but it asks with `isinstance(x, jnp.ndarray)`, which is False for `np.ndarray`. NumPy leaves skip the check. The sampler slices them anyway, since `_tree_slice` and `_stack` both use `eqx.is_array`, so a short NumPy leaf reaches `jnp.take`, comes back NaN-padded, and `bernoulli(key, nan)` is always False. A 3-node head block with a length-2 numpy weight array compiles to per-node weights `[10. 20. nan]` and a third spin that never moves, with nothing raised.

Using `eqx.is_array` here puts the check on the same predicate as the code doing the gathering. One thing to flag: numpy scalars like `np.float32(1.0)` now raise at construction where they used to pass validation. They were already dead downstream, failing at compile with `ValueError: axis 0 is out of bounds for array of dimension 0`, so this just moves it earlier.

Full suite passes locally, 63 with the new cases.
